### PR TITLE
Adjust beta parameters to stabilise probability distribution

### DIFF
--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -210,7 +210,7 @@ class SimulationRules(Rules):
 
 class Simulation:
     """Simulate a set of elections."""
-    def __init__(self, sim_rules, e_rules, m_votes, std_param=0.1):
+    def __init__(self, sim_rules, e_rules, m_votes, stbl_param=100):
         self.num_total_simulations = sim_rules["simulation_count"]
         self.num_rulesets = len(e_rules)
         self.num_constituencies = len(m_votes)
@@ -229,8 +229,8 @@ class Simulation:
         self.xtd_votes = add_totals(self.base_votes)
         self.xtd_vote_shares = find_xtd_shares(self.xtd_votes)
         self.variate = self.sim_rules["gen_method"]
-        self.std_param = std_param
-        self.stbl_param = 1.0/std_param**2
+        self.std_param = 1/sqrt(stbl_param)
+        self.stbl_param = stbl_param
         self.iteration = 0
         self.terminate = False
         self.iteration_time = timedelta(0)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 
 
 def beta_params(mean, deviation_param):
+    assert(0<mean and mean<1)
     weight = 1/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -21,8 +21,8 @@ def beta_params(mean, deviation_param):
     assert(0<lower_mean and lower_mean<=0.5)
     lifting_factor = 1 + 1.0/lower_mean
     weight = lifting_factor*stability_parameter - 1
-    alpha = weight*mean
-    beta = weight*(1-mean)
+    alpha = mean*weight
+    beta = (1-mean)*weight
     assert(alpha>1)
     assert(beta>1)
     return alpha, beta

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -58,7 +58,6 @@ def beta_distribution(
             mean_beta_distr = xtd_shares[c][p]
             assert(0 <= mean_beta_distr and mean_beta_distr <= 1)
             if 0 < mean_beta_distr and mean_beta_distr < 1:
-                var_beta = std_param*mean_beta_distr*(1-mean_beta_distr)
                 alpha, beta = beta_params(mean_beta_distr, std_param)
                 share = betavariate(alpha, beta)
             else:

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -38,16 +38,13 @@ def beta_params(mean, stability_parameter):
 
 def beta_distribution(
     base_votes, #2d - votes for each list,
-    std_param   #distribution parameter in range (0,1)
+    stab_param  #stability parameter in range (1,->)
 ):
     """
     Generate a set of votes with beta distribution,
     using 'base_votes' as reference.
     """
-    assert(0 < std_param and std_param < 1)
-    stab_param = 1.0/std_param**2
     assert(1<stab_param)
-
     xtd_votes = add_totals(base_votes)
     xtd_shares = find_xtd_shares(xtd_votes)
 
@@ -233,6 +230,7 @@ class Simulation:
         self.xtd_vote_shares = find_xtd_shares(self.xtd_votes)
         self.variate = self.sim_rules["gen_method"]
         self.std_param = std_param
+        self.stbl_param = 1.0/std_param**2
         self.iteration = 0
         self.terminate = False
         self.iteration_time = timedelta(0)
@@ -324,7 +322,7 @@ class Simulation:
         """
         gen = GENERATING_METHODS[self.variate]
         while True:
-            votes = gen(self.base_votes, self.std_param)
+            votes = gen(self.base_votes, self.stbl_param)
             xtd_votes  = add_totals(votes)
             xtd_shares = find_xtd_shares(xtd_votes)
             for c in range(self.num_constituencies+1):

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -25,6 +25,7 @@ def beta_params(mean, deviation_param):
     beta = (1-mean)*weight
     assert(alpha>1)
     assert(beta>1)
+    assert(weight == alpha+beta)
     return alpha, beta
 
 def beta_distribution(

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -38,13 +38,13 @@ def beta_params(mean, stability_parameter):
 
 def beta_distribution(
     base_votes, #2d - votes for each list,
-    stab_param  #stability parameter in range (1,->)
+    stbl_param  #stability parameter in range (1,->)
 ):
     """
     Generate a set of votes with beta distribution,
     using 'base_votes' as reference.
     """
-    assert(1<stab_param)
+    assert(1<stbl_param)
     xtd_votes = add_totals(base_votes)
     xtd_shares = find_xtd_shares(xtd_votes)
 
@@ -56,7 +56,7 @@ def beta_distribution(
             mean_beta_distr = xtd_shares[c][p]
             assert(0 <= mean_beta_distr and mean_beta_distr <= 1)
             if 0 < mean_beta_distr and mean_beta_distr < 1:
-                alpha, beta = beta_params(mean_beta_distr, stab_param)
+                alpha, beta = beta_params(mean_beta_distr, stbl_param)
                 share = betavariate(alpha, beta)
             else:
                 share = mean_beta_distr #either 0 or 1

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -13,12 +13,14 @@ from datetime import datetime, timedelta
 
 def beta_params(mean, deviation_param):
     assert(0<deviation_param and deviation_param<1)
+    stability_parameter = 1.0/deviation_param**2
+    assert(1<stability_parameter)
     assert(0<mean and mean<1)
     #make sure alpha and beta >1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)
     lifting_factor = 1 + 1.0/lower_mean
-    weight = lifting_factor/deviation_param**2 - 1
+    weight = lifting_factor*stability_parameter - 1
     alpha = weight*mean
     beta = weight*(1-mean)
     assert(alpha>1)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 
 def beta_params(mean, deviation_param):
     assert(0<mean and mean<1)
+    #TODO: make sure alpha and beta >=1 to ensure nice probability distribution
     weight = 1/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -18,9 +18,11 @@ def beta_params(mean, deviation_param):
     assert(0<lower_mean and lower_mean<=0.5)
     lifting_factor = 1 + 1.0/lower_mean
     assert(lifting_factor>=3)
-    weight = 1/deviation_param**2 - 1
+    weight = lifting_factor/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)
+    assert(alpha>=1)
+    assert(beta>=1)
     return alpha, beta
 
 def beta_distribution(

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 
 
 def beta_params(mean, deviation_param):
+    assert(0<deviation_param and deviation_param<=1)
     assert(0<mean and mean<1)
     #TODO: make sure alpha and beta >=1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -14,6 +14,8 @@ from datetime import datetime, timedelta
 def beta_params(mean, deviation_param):
     assert(0<mean and mean<1)
     #TODO: make sure alpha and beta >=1 to ensure nice probability distribution
+    lower_mean = mean if mean<=0.5 else 1-mean
+    assert(0<lower_mean and lower_mean<=0.5)
     weight = 1/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 def beta_params(mean, std_param):
     weight = 1/std_param**2 - 1
     alpha = weight*mean
-    beta = alpha*(1/mean - 1)
+    beta = weight*mean*(1/mean - 1)
     return alpha, beta
 
 def beta_distribution(

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -12,17 +12,17 @@ from datetime import datetime, timedelta
 
 
 def beta_params(mean, deviation_param):
-    assert(0<deviation_param and deviation_param<=1)
+    assert(0<deviation_param and deviation_param<1)
     assert(0<mean and mean<1)
-    #TODO: make sure alpha and beta >=1 to ensure nice probability distribution
+    #TODO: make sure alpha and beta >1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)
     lifting_factor = 1 + 1.0/lower_mean
     weight = lifting_factor/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)
-    assert(alpha>=1)
-    assert(beta>=1)
+    assert(alpha>1)
+    assert(beta>1)
     return alpha, beta
 
 def beta_distribution(

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -11,10 +11,8 @@ import json
 from datetime import datetime, timedelta
 
 
-def beta_params(mean, deviation_param):
+def beta_params(mean, stability_parameter):
     assert(0<mean and mean<1)
-    assert(0<deviation_param and deviation_param<1)
-    stability_parameter = 1.0/deviation_param**2
     assert(1<stability_parameter)
 
     #make sure alpha and beta >1 to ensure nice probability distribution
@@ -47,6 +45,9 @@ def beta_distribution(
     using 'base_votes' as reference.
     """
     assert(0 < std_param and std_param < 1)
+    stab_param = 1.0/std_param**2
+    assert(1<stab_param)
+
     xtd_votes = add_totals(base_votes)
     xtd_shares = find_xtd_shares(xtd_votes)
 
@@ -58,7 +59,7 @@ def beta_distribution(
             mean_beta_distr = xtd_shares[c][p]
             assert(0 <= mean_beta_distr and mean_beta_distr <= 1)
             if 0 < mean_beta_distr and mean_beta_distr < 1:
-                alpha, beta = beta_params(mean_beta_distr, std_param)
+                alpha, beta = beta_params(mean_beta_distr, stab_param)
                 share = betavariate(alpha, beta)
             else:
                 share = mean_beta_distr #either 0 or 1

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -229,8 +229,8 @@ class Simulation:
         self.xtd_votes = add_totals(self.base_votes)
         self.xtd_vote_shares = find_xtd_shares(self.xtd_votes)
         self.variate = self.sim_rules["gen_method"]
-        self.std_param = 1/sqrt(stbl_param)
         self.stbl_param = stbl_param
+        self.std_param = 1/sqrt(self.stbl_param)
         self.iteration = 0
         self.terminate = False
         self.iteration_time = timedelta(0)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 def beta_params(mean, deviation_param):
     assert(0<deviation_param and deviation_param<1)
     assert(0<mean and mean<1)
-    #TODO: make sure alpha and beta >1 to ensure nice probability distribution
+    #make sure alpha and beta >1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)
     lifting_factor = 1 + 1.0/lower_mean

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -11,8 +11,8 @@ import json
 from datetime import datetime, timedelta
 
 
-def beta_params(mean, std_param):
-    weight = 1/std_param**2 - 1
+def beta_params(mean, deviation_param):
+    weight = 1/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)
     return alpha, beta

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 
 def beta_params(mean, std_param):
     weight = 1/std_param**2 - 1
-    alpha = mean*weight
+    alpha = weight*mean
     beta = alpha*(1/mean - 1)
     return alpha, beta
 

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -17,7 +17,6 @@ def beta_params(mean, deviation_param):
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)
     lifting_factor = 1 + 1.0/lower_mean
-    assert(lifting_factor>=3)
     weight = lifting_factor/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -16,11 +16,21 @@ def beta_params(mean, deviation_param):
     assert(0<deviation_param and deviation_param<1)
     stability_parameter = 1.0/deviation_param**2
     assert(1<stability_parameter)
+
     #make sure alpha and beta >1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)
+
     lifting_factor = 1 + 1.0/lower_mean
+    assert(lifting_factor>=3)
+    assert(lifting_factor >= 1+1/mean)
+    assert(lifting_factor >= 1+1/(1-mean))
+
     weight = lifting_factor*stability_parameter - 1
+    assert(weight>2)
+    assert(weight > 1/mean)
+    assert(weight > 1/(1-mean))
+
     alpha = mean*weight
     beta = (1-mean)*weight
     #note that weight=alpha+beta

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -12,7 +12,8 @@ from datetime import datetime, timedelta
 
 
 def beta_params(mean, std_param):
-    alpha = mean*(1/std_param**2 - 1)
+    weight = 1/std_param**2 - 1
+    alpha = mean*weight
     beta = alpha*(1/mean - 1)
     return alpha, beta
 

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -12,10 +12,10 @@ from datetime import datetime, timedelta
 
 
 def beta_params(mean, deviation_param):
+    assert(0<mean and mean<1)
     assert(0<deviation_param and deviation_param<1)
     stability_parameter = 1.0/deviation_param**2
     assert(1<stability_parameter)
-    assert(0<mean and mean<1)
     #make sure alpha and beta >1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -230,7 +230,6 @@ class Simulation:
         self.xtd_vote_shares = find_xtd_shares(self.xtd_votes)
         self.variate = self.sim_rules["gen_method"]
         self.stbl_param = stbl_param
-        self.std_param = 1/sqrt(self.stbl_param)
         self.iteration = 0
         self.terminate = False
         self.iteration_time = timedelta(0)
@@ -340,7 +339,7 @@ class Simulation:
             for p in range(1+self.num_parties):
                 for measure in VOTE_MEASURES.keys():
                     self.analyze_list(-1, measure, c, p)
-                var_beta_distr[c].append(self.std_param
+                var_beta_distr[c].append(1/sqrt(self.stbl_param)
                                         *self.xtd_vote_shares[c][p]
                                         *(self.xtd_vote_shares[c][p]-1))
         sim_shares = self.list_data[-1]["sim_shares"]

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 def beta_params(mean, std_param):
     weight = 1/std_param**2 - 1
     alpha = weight*mean
-    beta = weight*mean*(1/mean - 1)
+    beta = weight*(1-mean)
     return alpha, beta
 
 def beta_distribution(

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -23,9 +23,9 @@ def beta_params(mean, deviation_param):
     weight = lifting_factor*stability_parameter - 1
     alpha = mean*weight
     beta = (1-mean)*weight
+    #note that weight=alpha+beta
     assert(alpha>1)
     assert(beta>1)
-    assert(weight == alpha+beta)
     return alpha, beta
 
 def beta_distribution(

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -16,6 +16,8 @@ def beta_params(mean, deviation_param):
     #TODO: make sure alpha and beta >=1 to ensure nice probability distribution
     lower_mean = mean if mean<=0.5 else 1-mean
     assert(0<lower_mean and lower_mean<=0.5)
+    lifting_factor = 1 + 1.0/lower_mean
+    assert(lifting_factor>=3)
     weight = 1/deviation_param**2 - 1
     alpha = weight*mean
     beta = weight*(1-mean)

--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -25,7 +25,7 @@ class SimulationTest(TestCase):
         e_rules["constituency_adjustment_seats"] = [1, 2, 1]
         e_rules["parties"] = ["A", "B"]
         votes = [[500, 300], [200, 400], [350, 450]]
-        sim = simulate.Simulation(s_rules, [e_rules], votes, 0.1)
+        sim = simulate.Simulation(s_rules, [e_rules], votes, 100)
         gen = sim.gen_votes()
         r = []
         r_avg = []

--- a/backend/web.py
+++ b/backend/web.py
@@ -277,9 +277,11 @@ def set_up_simulation():
     for k, v in data["simulation_rules"].items():
         simulation_rules[k] = v
 
+    stability_parameter = 1.0/std_param**2
+
     try:
         simulation = sim.Simulation(
-            simulation_rules, rulesets, data["ref_votes"], std_param)
+            simulation_rules, rulesets, data["ref_votes"], stability_parameter)
     except ZeroDivisionError:
         return False, "Need to have more votes."
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -264,20 +264,16 @@ def set_up_simulation():
             if type(party) != int:
                 return False, "Votes must be numbers."
 
-    std_param = 0.1
-    if "std_param" in data:
-        std_param = data["std_param"]
-        if std_param <= 0:
-            return False, "Distribution parameter must be greater than 0."
-        if std_param >= 0.5:
-            return False, "Distribution parameter must be less than 0.5."
+    stability_parameter = 100
+    if "stbl_param" in data:
+        stability_parameter = data["stbl_param"]
+        if stability_parameter <= 1:
+            return False, "Stability parameter must be greater than 1."
 
     simulation_rules = sim.SimulationRules()
 
     for k, v in data["simulation_rules"].items():
         simulation_rules[k] = v
-
-    stability_parameter = 1.0/std_param**2
 
     try:
         simulation = sim.Simulation(

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -257,7 +257,7 @@ export default {
           ref_votes: this.ref_votes,
           election_rules: this.election_rules,
           simulation_rules: this.simulation_rules,
-          std_param: this.distribution_parameter,
+          stbl_param: this.distribution_parameter,
           parties: this.parties,
           constituency_names: this.constituency_names,
           constituency_seats: this.constituency_seats,

--- a/vue-frontend/src/components/SimulationSettings.vue
+++ b/vue-frontend/src/components/SimulationSettings.vue
@@ -8,7 +8,7 @@
           </b-form-group>
         </b-col>
         <b-col>
-          <b-form-group label="Generating method" description="Which method should be used to generate votes?">
+          <b-form-group label="Generating method" description="Which method should be used to generate random votes?">
             <b-form-select v-model="rules.simulation_rules.gen_method" :options="rules.capabilities.generating_methods" class="mb-3"/>
           </b-form-group>
         </b-col>

--- a/vue-frontend/src/components/SimulationSettings.vue
+++ b/vue-frontend/src/components/SimulationSettings.vue
@@ -14,8 +14,8 @@
         </b-col>
         <b-col>
           <b-form-group
-            label="Distribution parameter"
-            description="What parameter should be used for the standard deviation of the distribution? (must be greater than 0 and less than 0.5)">
+            label="Stability parameter"
+            description="To influence the standard deviation of the distribution, please provide a number greater than 1 (does not need to be an integer, and values close to 1 are allowed, such as 1.0001). This number represents stability, in some sense. Higher values result in lower standard deviation, and vice versa.">
             <b-input-group>
               <b-form-input type="text"
                 v-model.number="distribution_parameter"/>
@@ -57,7 +57,7 @@ export default {
   created: function() {
     this.$http.get('/api/capabilities').then(response => {
       this.rules = response.body;
-      this.distribution_parameter = 0.1;
+      this.distribution_parameter = 100;
       this.doneCreating = true;
     }, response => {
       this.serverError = true;


### PR DESCRIPTION
We are randomising the vote results around some base vote results, by introducing a variation in the vote results for each list. So, for each list, we want the random data to have a probability distribution with a mean identical to the starting value. Furthermore, we want the user to be able to control how much variation the probability distribution should have.
To that effect, we provide an interface for an input parameter to influence the standard deviation.

As of yet, we have only implemented one method of generating the random vote results, using the Beta distribution as probability distribution. The Beta distribution takes to parameters, alpha and beta, which we prepare based on the given mean and desired standard deviation, indicated by the previously mentioned input parameter. We have restricted the value of the input parameter to ensure that alpha and beta can never be 0 (or less), but so far we have not been taking any precautions to ensure these parameter will not be less than 1.

But for our purposes, this is desirable, so this pull request is intended to fix that, to ensure that the alpha and beta parameters for the Beta distribution be no less than 1.

Furthermore, the above mentioned input parameter can not alone control the variation, because the mean must also be taken into account.
Nevertheless, we have, until now, been thinking about this parameter as if it controls the standard deviation directly, which is a little misleading.

So I propose that we replace the parameter with a related parameter, a kind of inversion of the previous one, which can be interpreted as a kind of stability parameter. It would be restricted to values no less than 1, and the higher the value, the more stability and less variation (the generated random votes will be centred more tightly around the given mean)