### PR TITLE
Base benchmark

### DIFF
--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -10,38 +10,39 @@ import util
 
 class SimulationTest(TestCase):
     def setUp(self):
-        pass
+        self.e_rules = voting.ElectionRules()
+        self.e_rules["constituency_names"] = ["I", "II", "III"]
+        self.e_rules["constituency_seats"] = [5, 6, 4]
+        self.e_rules["constituency_adjustment_seats"] = [1, 2, 1]
+        self.e_rules["parties"] = ["A", "B"]
+        self.votes = [[500, 300], [200, 400], [350, 450]]
+        self.s_rules = simulate.SimulationRules()
+        self.s_rules["simulation_count"] = 100
 
     def test_generate_votes(self):
         pass
         # Generate a few vote sets
 
     def test_generate_votes_average(self):
-        s_rules = simulate.SimulationRules()
-        s_rules["simulation_count"] = 1000
-        e_rules = voting.ElectionRules()
-        e_rules["constituency_names"] = ["I", "II", "III"]
-        e_rules["constituency_seats"] = [5, 6, 4]
-        e_rules["constituency_adjustment_seats"] = [1, 2, 1]
-        e_rules["parties"] = ["A", "B"]
-        votes = [[500, 300], [200, 400], [350, 450]]
-        sim = simulate.Simulation(s_rules, [e_rules], votes, 100)
+        n = 1000
+        self.s_rules["simulation_count"] = n
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
         gen = sim.gen_votes()
         r = []
         r_avg = []
         r_var = []
-        for k in range(s_rules["simulation_count"]):
+        for k in range(n):
             r.append([])
             generated_votes = next(gen)
-            for i in range(len(votes)):
+            for i in range(len(self.votes)):
                 r[k].append([])
-                for j in range(len(votes[i])):
+                for j in range(len(self.votes[i])):
                     r[k][i].append(uniform(0.0,1.0))
-        for i in range(len(votes)):
+        for i in range(len(self.votes)):
             r_avg.append([])
             r_var.append([])
-            for j in range(len(votes[i])):
-                r_ij = [r[k][i][j] for k in range(s_rules["simulation_count"])]
+            for j in range(len(self.votes[i])):
+                r_ij = [r[k][i][j] for k in range(n)]
                 # average = simulate.avg(r_ij)
                 # r_avg[i].append(average)
                 # r_var[i].append(simulate.var(r_ij, average))
@@ -54,3 +55,82 @@ class SimulationTest(TestCase):
 
 
         # Verify that µ=0.5±2%
+
+    def test_simulate_not_at_all(self):
+        #Arrange
+        self.s_rules["simulation_count"] = 0
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
+        #Act
+        sim.simulate()
+        #Assert
+        result = sim.get_results_dict()
+        vote_data = result['vote_data']['sim_votes']
+        list_measures = result['data'][0]['list_measures']
+        for const in range(sim.num_constituencies):
+            for party in range(sim.num_parties):
+                self.assertEqual(
+                    vote_data['sum'][const][party], self.votes[const][party]
+                )
+                self.assertEqual(
+                    vote_data['avg'][const][party], self.votes[const][party]
+                )
+                self.assertEqual(vote_data['cnt'][const][party], 1)
+                self.assertEqual(vote_data['var'][const][party], 0)
+                self.assertEqual(vote_data['std'][const][party], 0)
+                for m in simulate.LIST_MEASURES.keys():
+                    self.assertEqual(list_measures[m]['cnt'][const][party], 1)
+                    self.assertEqual(list_measures[m]['var'][const][party], 0)
+                    self.assertEqual(list_measures[m]['std'][const][party], 0)
+        measures = result['data'][0]['measures']
+        for m in simulate.MEASURES.keys():
+            self.assertEqual(measures[m]['cnt'], 1)
+            self.assertEqual(measures[m]['var'], 0)
+            self.assertEqual(measures[m]['std'], 0)
+
+    def test_simulate_once(self):
+        #Arrange
+        self.s_rules["simulation_count"] = 1
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
+        #Act
+        sim.simulate()
+        #Assert
+        result = sim.get_results_dict()
+        vote_data = result['vote_data']['sim_votes']
+        list_measures = result['data'][0]['list_measures']
+        for const in range(sim.num_constituencies):
+            for party in range(sim.num_parties):
+                self.assertGreater(vote_data['sum'][const][party], 0)
+                self.assertGreater(vote_data['avg'][const][party], 0)
+                self.assertEqual(vote_data['cnt'][const][party], 1)
+                self.assertEqual(vote_data['var'][const][party], 0)
+                self.assertEqual(vote_data['std'][const][party], 0)
+                for m in simulate.LIST_MEASURES.keys():
+                    self.assertEqual(list_measures[m]['cnt'][const][party], 1)
+                    self.assertEqual(list_measures[m]['var'][const][party], 0)
+                    self.assertEqual(list_measures[m]['std'][const][party], 0)
+        measures = result['data'][0]['measures']
+        for m in simulate.MEASURES.keys():
+            self.assertEqual(measures[m]['cnt'], 1)
+            self.assertEqual(measures[m]['var'], 0)
+            self.assertEqual(measures[m]['std'], 0)
+
+    def test_simulate(self):
+        #Arrange
+        self.s_rules["simulation_count"] = 100
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, 100)
+        #Act
+        sim.simulate()
+        #Assert
+        result = sim.get_results_dict()
+        vote_data = result['vote_data']['sim_votes']
+        list_measures = result['data'][0]['list_measures']
+        for const in range(sim.num_constituencies):
+            for party in range(sim.num_parties):
+                self.assertGreater(vote_data['sum'][const][party], 0)
+                self.assertGreater(vote_data['avg'][const][party], 0)
+                self.assertEqual(vote_data['cnt'][const][party], 100)
+                for m in simulate.LIST_MEASURES.keys():
+                    self.assertEqual(list_measures[m]['cnt'][const][party], 100)
+        measures = result['data'][0]['measures']
+        for m in simulate.MEASURES.keys():
+            self.assertEqual(measures[m]['cnt'], 100)


### PR DESCRIPTION
Add functionality for applying the measurements we have been using for the simulated results to the results of a single Election, to use as a benchmark for the measurements themselves.