### PR TITLE
Name vote tables, and display settings in excel output

### DIFF
--- a/backend/division_rules.py
+++ b/backend/division_rules.py
@@ -40,7 +40,7 @@ def danish_gen():
 def huntington_hill_gen():
     """Generate Huntington-Hill divider sequence; modified for hh(0) -> \inf"""
     n = 0
-    yield 10000000000
+    yield 0.00000000001
     while True:
         n += 1
         yield math.sqrt(n*(n+1))

--- a/backend/electionRules.py
+++ b/backend/electionRules.py
@@ -26,7 +26,7 @@ class ElectionRules(Rules):
             "constituency_names", "parties"
         ]
 
-        self["name"] = "My test"
+        self["name"] = "My electoral system"
 
         # Election rules
         self["primary_divider"] = "dhondt"

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -247,47 +247,35 @@ def simulation_to_xlsx(simulation, filename):
             },
         }
 
-        basic_info = [
-            {"label": "Date:",
-                "data": datetime.now()},
-            {"label": "Reference votes:",
-                "data": simulation.vote_table_name},
-            {"label": "Electoral system:",
-                "data": simulation.e_rules[r]["name"]},
-            {"label": "Adjustment method:",
-                "data": AMN[simulation.e_rules[r]["adjustment_method"]]},
-        ]
-        election_settings = [
-            {"label": "Rule for allocating constituency seats:",
-                "data": DRN[simulation.e_rules[r]["primary_divider"]]},
-            {"label": "Rule for dividing adjustment seats:",
-                "data": DRN[simulation.e_rules[r]["adj_determine_divider"]]},
-            {"label": "Rule for allocating adjustment seats:",
-                "data": DRN[simulation.e_rules[r]["adj_alloc_divider"]]},
-            {"label": "Threshold for dividing adjustment seats:",
-                "data": simulation.e_rules[r]["adjustment_threshold"]},
-        ]
-        simulation_settings = [
-            {"label": "Number of simulations:",
-                "data": simulation.num_total_simulations},
-            {"label": "Generating method:",
-                "data": GMN[simulation.variate]},
-            {"label": "Stability parameter:",
-                "data": simulation.stbl_param},
-        ]
         info_groups = [
-            {   "info": basic_info,
-                "left_span": 3,
-                "right_span": 5,
-            },
-            {   "info": election_settings,
-                "left_span": 5,
-                "right_span": 3,
-            },
-            {   "info": simulation_settings,
-                "left_span": 3,
-                "right_span": 3,
-            },
+            {"left_span": 3, "right_span": 5, "info": [
+                {"label": "Date:",
+                    "data": datetime.now()},
+                {"label": "Reference votes:",
+                    "data": simulation.vote_table_name},
+                {"label": "Electoral system:",
+                    "data": simulation.e_rules[r]["name"]},
+                {"label": "Adjustment method:",
+                    "data": AMN[simulation.e_rules[r]["adjustment_method"]]},
+            ]},
+            {"left_span": 5, "right_span": 3, "info": [
+                {"label": "Rule for allocating constituency seats:",
+                    "data": DRN[simulation.e_rules[r]["primary_divider"]]},
+                {"label": "Rule for dividing adjustment seats:",
+                    "data": DRN[simulation.e_rules[r]["adj_determine_divider"]]},
+                {"label": "Rule for allocating adjustment seats:",
+                    "data": DRN[simulation.e_rules[r]["adj_alloc_divider"]]},
+                {"label": "Threshold for dividing adjustment seats:",
+                    "data": simulation.e_rules[r]["adjustment_threshold"]},
+            ]},
+            {"left_span": 3, "right_span": 3, "info": [
+                {"label": "Number of simulations:",
+                    "data": simulation.num_total_simulations},
+                {"label": "Generating method:",
+                    "data": GMN[simulation.variate]},
+                {"label": "Stability parameter:",
+                    "data": simulation.stbl_param},
+            ]},
         ]
 
         toprow = 0

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -248,11 +248,24 @@ def simulation_to_xlsx(simulation, filename):
         }
         toprow = 0
         #Basic info
-        worksheet.merge_range(toprow,0,toprow,1,"Test name:",h_format)
-        worksheet.write(toprow,2,simulation.e_rules[r]["name"],basic_format)
-        worksheet.merge_range(toprow+1,0,toprow+1,1,"Date:",h_format)
-        worksheet.merge_range(toprow+1,2,toprow+1,3,datetime.now(),time_format)
-        toprow += 2+2
+        col=0
+        worksheet.merge_range(toprow,col,toprow,col+1,"Date:",h_format)
+        worksheet.merge_range(toprow,col+2,toprow,col+3,datetime.now(),time_format)
+        worksheet.merge_range(toprow+1,col,toprow+1,col+1,"Test name:",h_format)
+        worksheet.write(toprow+1,col+2,simulation.e_rules[r]["name"],basic_format)
+        worksheet.merge_range(toprow+2,col,toprow+2,col+1,"Adjustment method",h_format)
+        worksheet.write(toprow+2,col+2,simulation.e_rules[r]["adjustment_method"],basic_format)
+
+        col=8
+        worksheet.write(toprow,col,"Primary division rule",h_format)
+        worksheet.write(toprow,col+1,simulation.e_rules[r]["primary_divider"],basic_format)
+        worksheet.write(toprow+1,col,"Adjustment determination division rule",h_format)
+        worksheet.write(toprow+1,col+1,simulation.e_rules[r]["adj_determine_divider"],basic_format)
+        worksheet.write(toprow+2,col,"Adjustment allocation division rule",h_format)
+        worksheet.write(toprow+2,col+1,simulation.e_rules[r]["adj_alloc_divider"],basic_format)
+        worksheet.write(toprow+3,col,"Adjustment threshold",h_format)
+        worksheet.write(toprow+3,col+1,simulation.e_rules[r]["adjustment_threshold"],cell_format)
+        toprow += 4+2
         #vote data name
         #settings
 

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -248,26 +248,37 @@ def simulation_to_xlsx(simulation, filename):
         }
         toprow = 0
         #Basic info
+        row=toprow
         col=0
-        worksheet.merge_range(toprow,col,toprow,col+1,"Date:",h_format)
-        worksheet.merge_range(toprow,col+2,toprow,col+3,datetime.now(),time_format)
-        worksheet.merge_range(toprow+1,col,toprow+1,col+1,"Vote name:",h_format)
-        worksheet.write(toprow+1,col+2,simulation.vote_table_name,basic_format)
-        worksheet.merge_range(toprow+2,col,toprow+2,col+1,"Test name:",h_format)
-        worksheet.write(toprow+2,col+2,simulation.e_rules[r]["name"],basic_format)
-        worksheet.merge_range(toprow+3,col,toprow+3,col+1,"Adjustment method",h_format)
-        worksheet.write(toprow+3,col+2,simulation.e_rules[r]["adjustment_method"],basic_format)
+        cr=col+2
+        worksheet.merge_range(row,col,row,col+1,"Date:",h_format)
+        worksheet.merge_range(row,cr,row,cr+1,datetime.now(),time_format)
+        row += 1
+        worksheet.merge_range(row,col,row,col+1,"Vote name:",h_format)
+        worksheet.write(row,cr,simulation.vote_table_name,basic_format)
+        row += 1
+        worksheet.merge_range(row,col,row,col+1,"Test name:",h_format)
+        worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
+        row += 1
+        worksheet.merge_range(row,col,row,col+1,"Adjustment method",h_format)
+        worksheet.write(row,cr,simulation.e_rules[r]["adjustment_method"],basic_format)
 
         col=8
-        worksheet.write(toprow,col,"Primary division rule",h_format)
-        worksheet.write(toprow,col+1,simulation.e_rules[r]["primary_divider"],basic_format)
-        worksheet.write(toprow+1,col,"Adjustment determination division rule",h_format)
-        worksheet.write(toprow+1,col+1,simulation.e_rules[r]["adj_determine_divider"],basic_format)
-        worksheet.write(toprow+2,col,"Adjustment allocation division rule",h_format)
-        worksheet.write(toprow+2,col+1,simulation.e_rules[r]["adj_alloc_divider"],basic_format)
-        worksheet.write(toprow+3,col,"Adjustment threshold",h_format)
-        worksheet.write(toprow+3,col+1,simulation.e_rules[r]["adjustment_threshold"],cell_format)
-        toprow += 4+2
+        row=toprow
+        worksheet.write(row,col,"Primary division rule",h_format)
+        worksheet.write(row,col+1,simulation.e_rules[r]["primary_divider"],basic_format)
+        row += 1
+        worksheet.write(row,col,"Adjustment determination division rule",h_format)
+        worksheet.write(row,col+1,simulation.e_rules[r]["adj_determine_divider"],basic_format)
+        row += 1
+        worksheet.write(row,col,"Adjustment allocation division rule",h_format)
+        worksheet.write(row,col+1,simulation.e_rules[r]["adj_alloc_divider"],basic_format)
+        row += 1
+        worksheet.write(row,col,"Adjustment threshold",h_format)
+        worksheet.write(row,col+1,simulation.e_rules[r]["adjustment_threshold"],cell_format)
+
+        padding=2
+        toprow += 4+padding
 
         #Election tables
         for category in categories:

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -220,6 +220,33 @@ def simulation_to_xlsx(simulation, filename):
         const_names = simulation.e_rules[r]["constituency_names"] + ["Total"]
         parties     = simulation.e_rules[r]["parties"           ] + ["Total"]
 
+        data_matrix = {
+            "base": {
+                "v" : simulation.xtd_votes,
+                "vs": simulation.xtd_vote_shares,
+                "cs": simulation.base_allocations[r]["xtd_const_seats"],
+                "as": simulation.base_allocations[r]["xtd_adj_seats"],
+                "ts": simulation.base_allocations[r]["xtd_total_seats"],
+                "ss": simulation.base_allocations[r]["xtd_seat_shares"],
+            },
+            "avg": {
+                "v" : simulation.list_data[-1]["sim_votes"  ]["avg"],
+                "vs": simulation.list_data[-1]["sim_shares" ]["avg"],
+                "cs": simulation.list_data[ r]["const_seats"]["avg"],
+                "as": simulation.list_data[ r]["adj_seats"  ]["avg"],
+                "ts": simulation.list_data[ r]["total_seats"]["avg"],
+                "ss": simulation.list_data[ r]["seat_shares"]["avg"],
+            },
+            "std": {
+                "v" : simulation.list_data[-1]["sim_votes"  ]["std"],
+                "vs": simulation.list_data[-1]["sim_shares" ]["std"],
+                "cs": simulation.list_data[ r]["const_seats"]["std"],
+                "as": simulation.list_data[ r]["adj_seats"  ]["std"],
+                "ts": simulation.list_data[ r]["total_seats"]["std"],
+                "ss": simulation.list_data[ r]["seat_shares"]["std"],
+            },
+        }
+
         basic_info = [
             {"label": "Date:",
                 "data": datetime.now()},
@@ -263,32 +290,6 @@ def simulation_to_xlsx(simulation, filename):
             },
         ]
 
-        data_matrix = {
-            "base": {
-                "v" : simulation.xtd_votes,
-                "vs": simulation.xtd_vote_shares,
-                "cs": simulation.base_allocations[r]["xtd_const_seats"],
-                "as": simulation.base_allocations[r]["xtd_adj_seats"],
-                "ts": simulation.base_allocations[r]["xtd_total_seats"],
-                "ss": simulation.base_allocations[r]["xtd_seat_shares"],
-            },
-            "avg": {
-                "v" : simulation.list_data[-1]["sim_votes"  ]["avg"],
-                "vs": simulation.list_data[-1]["sim_shares" ]["avg"],
-                "cs": simulation.list_data[ r]["const_seats"]["avg"],
-                "as": simulation.list_data[ r]["adj_seats"  ]["avg"],
-                "ts": simulation.list_data[ r]["total_seats"]["avg"],
-                "ss": simulation.list_data[ r]["seat_shares"]["avg"],
-            },
-            "std": {
-                "v" : simulation.list_data[-1]["sim_votes"  ]["std"],
-                "vs": simulation.list_data[-1]["sim_shares" ]["std"],
-                "cs": simulation.list_data[ r]["const_seats"]["std"],
-                "as": simulation.list_data[ r]["adj_seats"  ]["std"],
-                "ts": simulation.list_data[ r]["total_seats"]["std"],
-                "ss": simulation.list_data[ r]["seat_shares"]["std"],
-            },
-        }
         toprow = 0
         bottomrow = toprow
         c1=1

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -251,10 +251,12 @@ def simulation_to_xlsx(simulation, filename):
         col=0
         worksheet.merge_range(toprow,col,toprow,col+1,"Date:",h_format)
         worksheet.merge_range(toprow,col+2,toprow,col+3,datetime.now(),time_format)
-        worksheet.merge_range(toprow+1,col,toprow+1,col+1,"Test name:",h_format)
-        worksheet.write(toprow+1,col+2,simulation.e_rules[r]["name"],basic_format)
-        worksheet.merge_range(toprow+2,col,toprow+2,col+1,"Adjustment method",h_format)
-        worksheet.write(toprow+2,col+2,simulation.e_rules[r]["adjustment_method"],basic_format)
+        worksheet.merge_range(toprow+1,col,toprow+1,col+1,"Vote name:",h_format)
+        worksheet.write(toprow+1,col+2,simulation.vote_table_name,basic_format)
+        worksheet.merge_range(toprow+2,col,toprow+2,col+1,"Test name:",h_format)
+        worksheet.write(toprow+2,col+2,simulation.e_rules[r]["name"],basic_format)
+        worksheet.merge_range(toprow+3,col,toprow+3,col+1,"Adjustment method",h_format)
+        worksheet.write(toprow+3,col+2,simulation.e_rules[r]["adjustment_method"],basic_format)
 
         col=8
         worksheet.write(toprow,col,"Primary division rule",h_format)
@@ -266,8 +268,6 @@ def simulation_to_xlsx(simulation, filename):
         worksheet.write(toprow+3,col,"Adjustment threshold",h_format)
         worksheet.write(toprow+3,col+1,simulation.e_rules[r]["adjustment_threshold"],cell_format)
         toprow += 4+2
-        #vote data name
-        #settings
 
         #Election tables
         for category in categories:

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -197,7 +197,7 @@ def simulation_to_xlsx(simulation, filename):
     ]
 
     for r in range(len(simulation.e_rules)):
-        sheet_name  = simulation.e_rules[r]["name"]
+        sheet_name  = f'{r+1}-{simulation.e_rules[r]["name"]}'
         worksheet   = workbook.add_worksheet(sheet_name)
         const_names = simulation.e_rules[r]["constituency_names"] + ["Total"]
         parties     = simulation.e_rules[r]["parties"           ] + ["Total"]

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -247,9 +247,10 @@ def simulation_to_xlsx(simulation, filename):
             },
         }
 
+        date_label = "Date:"
         info_groups = [
             {"left_span": 3, "right_span": 5, "info": [
-                {"label": "Date:",
+                {"label": date_label,
                     "data": datetime.now()},
                 {"label": "Reference votes:",
                     "data": simulation.vote_table_name},
@@ -287,7 +288,7 @@ def simulation_to_xlsx(simulation, filename):
             c2 = c1 + group["left_span"]
             for info in group["info"]:
                 worksheet.merge_range(row,c1,row,c2-1,info["label"],basic_h_format)
-                if info["label"] == "Date:":
+                if info["label"] == date_label:
                     worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
                 else:
                     worksheet.write(row,c2,info["data"],basic_format)

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -1,5 +1,6 @@
 
 import xlsxwriter
+from datetime import datetime
 
 from util import ADJUSTMENT_METHODS
 from table_util import matrix_subtraction, add_totals, find_xtd_shares
@@ -35,6 +36,9 @@ def election_to_xlsx(election, filename):
     h_format.set_bold()
     h_format.set_font_size(14)
 
+    time_format = workbook.add_format()
+    time_format.set_num_format('d mmm yyyy hh:mm')
+
     worksheet.set_column('B:B', 20)
 
     def write_matrix(worksheet, startrow, startcol, matrix, cformat):
@@ -67,6 +71,13 @@ def election_to_xlsx(election, filename):
         write_matrix(worksheet, row+2, col+1, matrix, cformat)
 
     startcol = 1
+
+    toprow=0
+    worksheet.merge_range(toprow,0,toprow,1,"Test name:",h_format)
+    worksheet.merge_range(toprow,2,toprow,3,"My electoral system",cell_format)
+    worksheet.merge_range(toprow+1,0,toprow+1,1,"Date:",h_format)
+    worksheet.merge_range(toprow+1,2,toprow+1,3,datetime.now(),time_format)
+
     startrow = 4
     tables_before = [
         {"heading": "Votes",              "matrix": xtd_votes      },
@@ -156,6 +167,9 @@ def simulation_to_xlsx(simulation, filename):
     share_format = workbook.add_format()
     share_format.set_num_format('0.0%')
 
+    time_format = workbook.add_format()
+    time_format.set_num_format('d mmm yyyy hh:mm')
+
 
     def write_matrix(worksheet, startrow, startcol, matrix, cformat):
         for c in range(len(matrix)):
@@ -228,7 +242,17 @@ def simulation_to_xlsx(simulation, filename):
                 "ss": simulation.list_data[ r]["seat_shares"]["std"],
             },
         }
-        toprow = 3
+        toprow = 0
+        #Basic info
+        worksheet.merge_range(toprow,0,toprow,1,"Test name:",h_format)
+        worksheet.merge_range(toprow,2,toprow,3,simulation.e_rules[r]["name"],cell_format)
+        worksheet.merge_range(toprow+1,0,toprow+1,1,"Date:",h_format)
+        worksheet.merge_range(toprow+1,2,toprow+1,3,datetime.now(),time_format)
+        toprow += 2+2
+        #vote data name
+        #settings
+
+        #Election tables
         for category in categories:
             worksheet.merge_range(toprow, 0, toprow+1+len(const_names), 0,
                 category["heading"], r_format)
@@ -244,6 +268,7 @@ def simulation_to_xlsx(simulation, filename):
                 col += len(parties)+2
             toprow += len(const_names)+3
 
+        #Measures
         results = simulation.get_results_dict()
         DEVIATION_MEASURES = results["deviation_measures"]
         STANDARDIZED_MEASURES = results["standardized_measures"]

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -285,7 +285,7 @@ def simulation_to_xlsx(simulation, filename):
         worksheet.merge_range(row,col,row,cr-1,"Rule for allocating adjustment seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Threshold for division of adjustment seats:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Threshold for dividing adjustment seats:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)
 
         row=toprow

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -294,6 +294,16 @@ def simulation_to_xlsx(simulation, filename):
                 row += 1
             bottomrow = max(row, bottomrow)
             c1 = c2 + group["right_span"]
+
+        draw_block(worksheet, row=toprow, col=c1,
+            heading="Desired number of seats",
+            xheaders=["cons", "adj", "total"],
+            yheaders=const_names,
+            matrix=add_totals([[simulation.e_rules[r]["constituency_seats"][c],
+                     simulation.e_rules[r]["constituency_adjustment_seats"][c]]
+                for c in range(simulation.num_constituencies)])
+        )
+        bottomrow = max(2+len(const_names), bottomrow)
         toprow += bottomrow+2
 
         #Election tables

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -277,6 +277,17 @@ def simulation_to_xlsx(simulation, filename):
         worksheet.write(row,col,"Adjustment threshold",h_format)
         worksheet.write(row,col+1,simulation.e_rules[r]["adjustment_threshold"],cell_format)
 
+        col=16
+        row=toprow
+        worksheet.write(row,col,"Number of simulations",h_format)
+        worksheet.write(row,col+1,simulation.num_total_simulations,basic_format)
+        row += 1
+        worksheet.write(row,col,"Generating method",h_format)
+        worksheet.write(row,col+1,simulation.variate,basic_format)
+        row += 1
+        worksheet.write(row,col,"Stability parameter",h_format)
+        worksheet.write(row,col+1,simulation.stbl_param,basic_format)
+
         padding=2
         toprow += 4+padding
 

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -248,6 +248,20 @@ def simulation_to_xlsx(simulation, filename):
             {"label": "Stability parameter:",
                 "data": simulation.stbl_param},
         ]
+        info_groups = [
+            {   "info": basic_info,
+                "left_span": 3,
+                "right_span": 5,
+            },
+            {   "info": election_settings,
+                "left_span": 6,
+                "right_span": 3,
+            },
+            {   "info": simulation_settings,
+                "left_span": 3,
+                "right_span": 3,
+            },
+        ]
 
         data_matrix = {
             "base": {
@@ -279,45 +293,20 @@ def simulation_to_xlsx(simulation, filename):
         bottomrow = toprow
         col=1
         #Basic info
-        row=toprow
-        span=3
-        c2=col+span
-        for info in basic_info:
-            worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            if info["label"] == "Date:":
-                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
-            else:
-                worksheet.write(row,c2,info["data"],basic_format)
-            row += 1
-        bottomrow = max(row, bottomrow)
-        col+=span+5
-
-        row=toprow
-        span=6
-        c2=col+span
-        for info in election_settings:
-            worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            if info["label"] == "Date:":
-                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
-            else:
-                worksheet.write(row,c2,info["data"],basic_format)
-            row += 1
-        bottomrow = max(row, bottomrow)
-        col+=span+3
-
-        row=toprow
-        span=3
-        c2=col+span
-        for info in simulation_settings:
-            worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            if info["label"] == "Date:":
-                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
-            else:
-                worksheet.write(row,c2,info["data"],basic_format)
-            row += 1
-        bottomrow = max(row, bottomrow)
-
+        for group in info_groups:
+            row = toprow
+            c2 = col + group["left_span"]
+            for info in group["info"]:
+                worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
+                if info["label"] == "Date:":
+                    worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
+                else:
+                    worksheet.write(row,c2,info["data"],basic_format)
+                row += 1
+            bottomrow = max(row, bottomrow)
+            col = c2 + group["right_span"]
         toprow += bottomrow+2
+
         #Election tables
         for category in categories:
             worksheet.merge_range(toprow, 0, toprow+1+len(const_names), 0,

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -8,6 +8,16 @@ from dictionaries import ADJUSTMENT_METHOD_NAMES as AMN, \
                          DIVIDER_RULE_NAMES as DRN, \
                          GENERATING_METHOD_NAMES as GMN
 
+def write_matrix(worksheet, startrow, startcol, matrix, cformat):
+    for c in range(len(matrix)):
+        for p in range(len(matrix[c])):
+            if matrix[c][p] != 0:
+                try:
+                    worksheet.write(startrow+c, startcol+p, matrix[c][p],
+                                    cformat[c])
+                except TypeError:
+                    worksheet.write(startrow+c, startcol+p, matrix[c][p],
+                                    cformat)
 
 
 def election_to_xlsx(election, filename):
@@ -43,17 +53,6 @@ def election_to_xlsx(election, filename):
     time_format.set_num_format('d mmm yyyy hh:mm')
 
     worksheet.set_column('B:B', 20)
-
-    def write_matrix(worksheet, startrow, startcol, matrix, cformat):
-        for c in range(len(matrix)):
-            for p in range(len(matrix[c])):
-                if matrix[c][p] != 0:
-                    try:
-                        worksheet.write(startrow+c, startcol+p, matrix[c][p],
-                                        cformat[c])
-                    except TypeError:
-                        worksheet.write(startrow+c, startcol+p, matrix[c][p],
-                                        cformat)
 
     def draw_block(worksheet, row, col,
         heading, xheaders, yheaders,
@@ -182,13 +181,6 @@ def simulation_to_xlsx(simulation, filename):
     basic_h_format.set_bold()
     basic_h_format.set_font_size(12)
 
-
-    def write_matrix(worksheet, startrow, startcol, matrix, cformat):
-        for c in range(len(matrix)):
-            for p in range(len(matrix[c])):
-                if matrix[c][p] != 0:
-                    worksheet.write(startrow+c, startcol+p, matrix[c][p],
-                                    cformat)
 
     def draw_block(worksheet, row, col,
         heading, xheaders, yheaders,

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -247,6 +247,7 @@ def simulation_to_xlsx(simulation, filename):
             },
         }
         toprow = 0
+        bottomrow = toprow
         #Basic info
         row=toprow
         col=1
@@ -267,6 +268,7 @@ def simulation_to_xlsx(simulation, filename):
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
             worksheet.write(row,c2,info["data"],basic_format)
             row += 1
+        bottomrow = max(row, bottomrow)
 
         row=toprow
         col+=span+5
@@ -286,6 +288,7 @@ def simulation_to_xlsx(simulation, filename):
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
             worksheet.write(row,c2,info["data"],basic_format)
             row += 1
+        bottomrow = max(row, bottomrow)
 
         row=toprow
         col+=span+3
@@ -303,10 +306,9 @@ def simulation_to_xlsx(simulation, filename):
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
             worksheet.write(row,c2,info["data"],basic_format)
             row += 1
+        bottomrow = max(row, bottomrow)
 
-        padding=2
-        toprow += 4+padding
-
+        toprow += bottomrow+2
         #Election tables
         for category in categories:
             worksheet.merge_range(toprow, 0, toprow+1+len(const_names), 0,

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -4,6 +4,9 @@ from datetime import datetime
 
 from util import ADJUSTMENT_METHODS
 from table_util import matrix_subtraction, add_totals, find_xtd_shares
+from dictionaries import ADJUSTMENT_METHOD_NAMES as AMN, \
+                         DIVIDER_RULE_NAMES as DRM, \
+                         GENERATING_METHOD_NAMES as GMN
 
 
 
@@ -262,20 +265,20 @@ def simulation_to_xlsx(simulation, filename):
         worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment method",h_format)
-        worksheet.write(row,cr,simulation.e_rules[r]["adjustment_method"],basic_format)
+        worksheet.write(row,cr,AMN[simulation.e_rules[r]["adjustment_method"]],basic_format)
 
         row=toprow
-        col+=span+3
+        col+=span+5
         span=6
         cr=col+span
         worksheet.merge_range(row,col,row,cr-1,"Primary division rule",h_format)
-        worksheet.write(row,cr,simulation.e_rules[r]["primary_divider"],basic_format)
+        worksheet.write(row,cr,DRM[simulation.e_rules[r]["primary_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment determination division rule",h_format)
-        worksheet.write(row,cr,simulation.e_rules[r]["adj_determine_divider"],basic_format)
+        worksheet.write(row,cr,DRM[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment allocation division rule",h_format)
-        worksheet.write(row,cr,simulation.e_rules[r]["adj_alloc_divider"],basic_format)
+        worksheet.write(row,cr,DRM[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment threshold",h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)
@@ -288,7 +291,7 @@ def simulation_to_xlsx(simulation, filename):
         worksheet.write(row,cr,simulation.num_total_simulations,basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Generating method",h_format)
-        worksheet.write(row,cr,simulation.variate,basic_format)
+        worksheet.write(row,cr,GMN[simulation.variate],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Stability parameter",h_format)
         worksheet.write(row,cr,simulation.stbl_param,basic_format)

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -276,13 +276,13 @@ def simulation_to_xlsx(simulation, filename):
         col+=span+5
         span=6
         cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Division rule for allocation of constituency seats:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Rule for allocating constituency seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["primary_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Division rule for division of adjustment seats:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Rule for dividing adjustment seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Division rule for allocation of adjustment seats:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Rule for allocating adjustment seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Threshold for division of adjustment seats:",basic_h_format)

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from util import ADJUSTMENT_METHODS
 from table_util import matrix_subtraction, add_totals, find_xtd_shares
 from dictionaries import ADJUSTMENT_METHOD_NAMES as AMN, \
-                         DIVIDER_RULE_NAMES as DRM, \
+                         DIVIDER_RULE_NAMES as DRN, \
                          GENERATING_METHOD_NAMES as GMN
 
 
@@ -277,13 +277,13 @@ def simulation_to_xlsx(simulation, filename):
         span=5
         cr=col+span
         worksheet.merge_range(row,col,row,cr-1,"Primary division rule:",basic_h_format)
-        worksheet.write(row,cr,DRM[simulation.e_rules[r]["primary_divider"]],basic_format)
+        worksheet.write(row,cr,DRN[simulation.e_rules[r]["primary_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment determination division rule:",basic_h_format)
-        worksheet.write(row,cr,DRM[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
+        worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment allocation division rule:",basic_h_format)
-        worksheet.write(row,cr,DRM[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
+        worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment threshold:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -220,6 +220,33 @@ def simulation_to_xlsx(simulation, filename):
         const_names = simulation.e_rules[r]["constituency_names"] + ["Total"]
         parties     = simulation.e_rules[r]["parties"           ] + ["Total"]
 
+        basic_info = [
+            {"label": "Reference votes:",
+                "data": simulation.vote_table_name},
+            {"label": "Electoral system:",
+                "data": simulation.e_rules[r]["name"]},
+            {"label": "Adjustment method:",
+                "data": AMN[simulation.e_rules[r]["adjustment_method"]]},
+        ]
+        election_settings = [
+            {"label": "Rule for allocating constituency seats:",
+                "data": DRN[simulation.e_rules[r]["primary_divider"]]},
+            {"label": "Rule for dividing adjustment seats:",
+                "data": DRN[simulation.e_rules[r]["adj_determine_divider"]]},
+            {"label": "Rule for allocating adjustment seats:",
+                "data": DRN[simulation.e_rules[r]["adj_alloc_divider"]]},
+            {"label": "Threshold for dividing adjustment seats:",
+                "data": simulation.e_rules[r]["adjustment_threshold"]},
+        ]
+        simulation_settings = [
+            {"label": "Number of simulations:",
+                "data": simulation.num_total_simulations},
+            {"label": "Generating method:",
+                "data": GMN[simulation.variate]},
+            {"label": "Stability parameter:",
+                "data": simulation.stbl_param},
+        ]
+
         data_matrix = {
             "base": {
                 "v" : simulation.xtd_votes,
@@ -256,14 +283,6 @@ def simulation_to_xlsx(simulation, filename):
         worksheet.merge_range(row,col,row,c2-1,"Date:",basic_h_format)
         worksheet.merge_range(row,c2,row,c2+1,datetime.now(),time_format)
         row += 1
-        basic_info = [
-            {"label": "Reference votes:",
-                "data": simulation.vote_table_name},
-            {"label": "Electoral system:",
-                "data": simulation.e_rules[r]["name"]},
-            {"label": "Adjustment method:",
-                "data": AMN[simulation.e_rules[r]["adjustment_method"]]},
-        ]
         for info in basic_info:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
             worksheet.write(row,c2,info["data"],basic_format)
@@ -274,16 +293,6 @@ def simulation_to_xlsx(simulation, filename):
         col+=span+5
         span=6
         c2=col+span
-        election_settings = [
-            {"label": "Rule for allocating constituency seats:",
-                "data": DRN[simulation.e_rules[r]["primary_divider"]]},
-            {"label": "Rule for dividing adjustment seats:",
-                "data": DRN[simulation.e_rules[r]["adj_determine_divider"]]},
-            {"label": "Rule for allocating adjustment seats:",
-                "data": DRN[simulation.e_rules[r]["adj_alloc_divider"]]},
-            {"label": "Threshold for dividing adjustment seats:",
-                "data": simulation.e_rules[r]["adjustment_threshold"]},
-        ]
         for info in election_settings:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
             worksheet.write(row,c2,info["data"],basic_format)
@@ -294,14 +303,6 @@ def simulation_to_xlsx(simulation, filename):
         col+=span+3
         span=3
         c2=col+span
-        simulation_settings = [
-            {"label": "Number of simulations:",
-                "data": simulation.num_total_simulations},
-            {"label": "Generating method:",
-                "data": GMN[simulation.variate]},
-            {"label": "Stability parameter:",
-                "data": simulation.stbl_param},
-        ]
         for info in simulation_settings:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
             worksheet.write(row,c2,info["data"],basic_format)

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -177,6 +177,11 @@ def simulation_to_xlsx(simulation, filename):
     basic_format = workbook.add_format()
     basic_format.set_align('left')
 
+    basic_h_format = workbook.add_format()
+    basic_h_format.set_align('right')
+    basic_h_format.set_bold()
+    basic_h_format.set_font_size(12)
+
 
     def write_matrix(worksheet, startrow, startcol, matrix, cformat):
         for c in range(len(matrix)):
@@ -255,45 +260,45 @@ def simulation_to_xlsx(simulation, filename):
         col=0
         span=3
         cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Date:",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Date:",basic_h_format)
         worksheet.merge_range(row,cr,row,cr+1,datetime.now(),time_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Vote name:",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Vote name:",basic_h_format)
         worksheet.write(row,cr,simulation.vote_table_name,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Test name:",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Test name:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment method",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment method:",basic_h_format)
         worksheet.write(row,cr,AMN[simulation.e_rules[r]["adjustment_method"]],basic_format)
 
         row=toprow
         col+=span+5
-        span=6
+        span=5
         cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Primary division rule",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Primary division rule:",basic_h_format)
         worksheet.write(row,cr,DRM[simulation.e_rules[r]["primary_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment determination division rule",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment determination division rule:",basic_h_format)
         worksheet.write(row,cr,DRM[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment allocation division rule",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment allocation division rule:",basic_h_format)
         worksheet.write(row,cr,DRM[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment threshold",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment threshold:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)
 
         row=toprow
         col+=span+3
-        span=4
+        span=3
         cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Number of simulations",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Number of simulations:",basic_h_format)
         worksheet.write(row,cr,simulation.num_total_simulations,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Generating method",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Generating method:",basic_h_format)
         worksheet.write(row,cr,GMN[simulation.variate],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Stability parameter",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Stability parameter:",basic_h_format)
         worksheet.write(row,cr,simulation.stbl_param,basic_format)
 
         padding=2

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -272,17 +272,20 @@ def simulation_to_xlsx(simulation, filename):
         col+=span+5
         span=6
         c2=col+span
-        worksheet.merge_range(row,col,row,c2-1,"Rule for allocating constituency seats:",basic_h_format)
-        worksheet.write(row,c2,DRN[simulation.e_rules[r]["primary_divider"]],basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Rule for dividing adjustment seats:",basic_h_format)
-        worksheet.write(row,c2,DRN[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Rule for allocating adjustment seats:",basic_h_format)
-        worksheet.write(row,c2,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Threshold for dividing adjustment seats:",basic_h_format)
-        worksheet.write(row,c2,simulation.e_rules[r]["adjustment_threshold"],basic_format)
+        election_settings = [
+            {"label": "Rule for allocating constituency seats:",
+                "data": DRN[simulation.e_rules[r]["primary_divider"]]},
+            {"label": "Rule for dividing adjustment seats:",
+                "data": DRN[simulation.e_rules[r]["adj_determine_divider"]]},
+            {"label": "Rule for allocating adjustment seats:",
+                "data": DRN[simulation.e_rules[r]["adj_alloc_divider"]]},
+            {"label": "Threshold for dividing adjustment seats:",
+                "data": simulation.e_rules[r]["adjustment_threshold"]},
+        ]
+        for info in election_settings:
+            worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
+            worksheet.write(row,c2,info["data"],basic_format)
+            row += 1
 
         row=toprow
         col+=span+3

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -169,6 +169,10 @@ def simulation_to_xlsx(simulation, filename):
 
     time_format = workbook.add_format()
     time_format.set_num_format('d mmm yyyy hh:mm')
+    time_format.set_align('left')
+
+    basic_format = workbook.add_format()
+    basic_format.set_align('left')
 
 
     def write_matrix(worksheet, startrow, startcol, matrix, cformat):
@@ -245,7 +249,7 @@ def simulation_to_xlsx(simulation, filename):
         toprow = 0
         #Basic info
         worksheet.merge_range(toprow,0,toprow,1,"Test name:",h_format)
-        worksheet.merge_range(toprow,2,toprow,3,simulation.e_rules[r]["name"],cell_format)
+        worksheet.write(toprow,2,simulation.e_rules[r]["name"],basic_format)
         worksheet.merge_range(toprow+1,0,toprow+1,1,"Date:",h_format)
         worksheet.merge_range(toprow+1,2,toprow+1,3,datetime.now(),time_format)
         toprow += 2+2

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -259,47 +259,47 @@ def simulation_to_xlsx(simulation, filename):
         row=toprow
         col=1
         span=3
-        cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Date:",basic_h_format)
-        worksheet.merge_range(row,cr,row,cr+1,datetime.now(),time_format)
+        c2=col+span
+        worksheet.merge_range(row,col,row,c2-1,"Date:",basic_h_format)
+        worksheet.merge_range(row,c2,row,c2+1,datetime.now(),time_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Reference votes:",basic_h_format)
-        worksheet.write(row,cr,simulation.vote_table_name,basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Reference votes:",basic_h_format)
+        worksheet.write(row,c2,simulation.vote_table_name,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Electoral system:",basic_h_format)
-        worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Electoral system:",basic_h_format)
+        worksheet.write(row,c2,simulation.e_rules[r]["name"],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment method:",basic_h_format)
-        worksheet.write(row,cr,AMN[simulation.e_rules[r]["adjustment_method"]],basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Adjustment method:",basic_h_format)
+        worksheet.write(row,c2,AMN[simulation.e_rules[r]["adjustment_method"]],basic_format)
 
         row=toprow
         col+=span+5
         span=6
-        cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Rule for allocating constituency seats:",basic_h_format)
-        worksheet.write(row,cr,DRN[simulation.e_rules[r]["primary_divider"]],basic_format)
+        c2=col+span
+        worksheet.merge_range(row,col,row,c2-1,"Rule for allocating constituency seats:",basic_h_format)
+        worksheet.write(row,c2,DRN[simulation.e_rules[r]["primary_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Rule for dividing adjustment seats:",basic_h_format)
-        worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Rule for dividing adjustment seats:",basic_h_format)
+        worksheet.write(row,c2,DRN[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Rule for allocating adjustment seats:",basic_h_format)
-        worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Rule for allocating adjustment seats:",basic_h_format)
+        worksheet.write(row,c2,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Threshold for dividing adjustment seats:",basic_h_format)
-        worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Threshold for dividing adjustment seats:",basic_h_format)
+        worksheet.write(row,c2,simulation.e_rules[r]["adjustment_threshold"],basic_format)
 
         row=toprow
         col+=span+3
         span=3
-        cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Number of simulations:",basic_h_format)
-        worksheet.write(row,cr,simulation.num_total_simulations,basic_format)
+        c2=col+span
+        worksheet.merge_range(row,col,row,c2-1,"Number of simulations:",basic_h_format)
+        worksheet.write(row,c2,simulation.num_total_simulations,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Generating method:",basic_h_format)
-        worksheet.write(row,cr,GMN[simulation.variate],basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Generating method:",basic_h_format)
+        worksheet.write(row,c2,GMN[simulation.variate],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Stability parameter:",basic_h_format)
-        worksheet.write(row,cr,simulation.stbl_param,basic_format)
+        worksheet.merge_range(row,col,row,c2-1,"Stability parameter:",basic_h_format)
+        worksheet.write(row,c2,simulation.stbl_param,basic_format)
 
         padding=2
         toprow += 4+padding

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -252,17 +252,23 @@ def simulation_to_xlsx(simulation, filename):
         col=1
         span=3
         c2=col+span
-        worksheet.merge_range(row,col,row,c2-1,"Date:",basic_h_format)
-        worksheet.merge_range(row,c2,row,c2+1,datetime.now(),time_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Reference votes:",basic_h_format)
-        worksheet.write(row,c2,simulation.vote_table_name,basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Electoral system:",basic_h_format)
-        worksheet.write(row,c2,simulation.e_rules[r]["name"],basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Adjustment method:",basic_h_format)
-        worksheet.write(row,c2,AMN[simulation.e_rules[r]["adjustment_method"]],basic_format)
+        basic_info = [
+            {"label": "Date:",
+                "data": datetime.now()},
+            {"label": "Reference votes:",
+                "data": simulation.vote_table_name},
+            {"label": "Electoral system:",
+                "data": simulation.e_rules[r]["name"]},
+            {"label": "Adjustment method:",
+                "data": AMN[simulation.e_rules[r]["adjustment_method"]]},
+        ]
+        for info in basic_info:
+            worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
+            if info["label"] == "Date:":
+                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
+            else:
+                worksheet.write(row,c2,info["data"],basic_format)
+            row += 1
 
         row=toprow
         col+=span+5

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -344,3 +344,11 @@ def simulation_to_xlsx(simulation, filename):
         )
 
     workbook.close()
+
+def save_votes_to_xlsx(matrix, filename):
+    workbook = xlsxwriter.Workbook(filename)
+    worksheet = workbook.add_worksheet()
+    fmt = prepare_formats(workbook)
+    write_matrix(worksheet=worksheet, startrow=0, startcol=0,
+        matrix=matrix, cformat=fmt["cell"])
+    workbook.close()

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -250,43 +250,48 @@ def simulation_to_xlsx(simulation, filename):
         #Basic info
         row=toprow
         col=0
-        cr=col+2
-        worksheet.merge_range(row,col,row,col+1,"Date:",h_format)
+        span=3
+        cr=col+span
+        worksheet.merge_range(row,col,row,cr-1,"Date:",h_format)
         worksheet.merge_range(row,cr,row,cr+1,datetime.now(),time_format)
         row += 1
-        worksheet.merge_range(row,col,row,col+1,"Vote name:",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Vote name:",h_format)
         worksheet.write(row,cr,simulation.vote_table_name,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,col+1,"Test name:",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Test name:",h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,col+1,"Adjustment method",h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment method",h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["adjustment_method"],basic_format)
 
-        col=8
         row=toprow
-        worksheet.write(row,col,"Primary division rule",h_format)
-        worksheet.write(row,col+1,simulation.e_rules[r]["primary_divider"],basic_format)
+        col+=span+3
+        span=6
+        cr=col+span
+        worksheet.merge_range(row,col,row,cr-1,"Primary division rule",h_format)
+        worksheet.write(row,cr,simulation.e_rules[r]["primary_divider"],basic_format)
         row += 1
-        worksheet.write(row,col,"Adjustment determination division rule",h_format)
-        worksheet.write(row,col+1,simulation.e_rules[r]["adj_determine_divider"],basic_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment determination division rule",h_format)
+        worksheet.write(row,cr,simulation.e_rules[r]["adj_determine_divider"],basic_format)
         row += 1
-        worksheet.write(row,col,"Adjustment allocation division rule",h_format)
-        worksheet.write(row,col+1,simulation.e_rules[r]["adj_alloc_divider"],basic_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment allocation division rule",h_format)
+        worksheet.write(row,cr,simulation.e_rules[r]["adj_alloc_divider"],basic_format)
         row += 1
-        worksheet.write(row,col,"Adjustment threshold",h_format)
-        worksheet.write(row,col+1,simulation.e_rules[r]["adjustment_threshold"],cell_format)
+        worksheet.merge_range(row,col,row,cr-1,"Adjustment threshold",h_format)
+        worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)
 
-        col=16
         row=toprow
-        worksheet.write(row,col,"Number of simulations",h_format)
-        worksheet.write(row,col+1,simulation.num_total_simulations,basic_format)
+        col+=span+3
+        span=4
+        cr=col+span
+        worksheet.merge_range(row,col,row,cr-1,"Number of simulations",h_format)
+        worksheet.write(row,cr,simulation.num_total_simulations,basic_format)
         row += 1
-        worksheet.write(row,col,"Generating method",h_format)
-        worksheet.write(row,col+1,simulation.variate,basic_format)
+        worksheet.merge_range(row,col,row,cr-1,"Generating method",h_format)
+        worksheet.write(row,cr,simulation.variate,basic_format)
         row += 1
-        worksheet.write(row,col,"Stability parameter",h_format)
-        worksheet.write(row,col+1,simulation.stbl_param,basic_format)
+        worksheet.merge_range(row,col,row,cr-1,"Stability parameter",h_format)
+        worksheet.write(row,cr,simulation.stbl_param,basic_format)
 
         padding=2
         toprow += 4+padding

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -281,7 +281,7 @@ def simulation_to_xlsx(simulation, filename):
                 "right_span": 5,
             },
             {   "info": election_settings,
-                "left_span": 6,
+                "left_span": 5,
                 "right_span": 3,
             },
             {   "info": simulation_settings,

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -257,16 +257,16 @@ def simulation_to_xlsx(simulation, filename):
         toprow = 0
         #Basic info
         row=toprow
-        col=0
-        span=3
+        col=1
+        span=4
         cr=col+span
         worksheet.merge_range(row,col,row,cr-1,"Date:",basic_h_format)
         worksheet.merge_range(row,cr,row,cr+1,datetime.now(),time_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Vote name:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Vote data being used:",basic_h_format)
         worksheet.write(row,cr,simulation.vote_table_name,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Test name:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Electoral system being used:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment method:",basic_h_format)
@@ -274,18 +274,18 @@ def simulation_to_xlsx(simulation, filename):
 
         row=toprow
         col+=span+5
-        span=5
+        span=6
         cr=col+span
-        worksheet.merge_range(row,col,row,cr-1,"Primary division rule:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Division rule for allocation of constituency seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["primary_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment determination division rule:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Division rule for division of adjustment seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_determine_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment allocation division rule:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Division rule for allocation of adjustment seats:",basic_h_format)
         worksheet.write(row,cr,DRN[simulation.e_rules[r]["adj_alloc_divider"]],basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Adjustment threshold:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Threshold for division of adjustment seats:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["adjustment_threshold"],basic_format)
 
         row=toprow

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -291,20 +291,20 @@ def simulation_to_xlsx(simulation, filename):
         }
         toprow = 0
         bottomrow = toprow
-        col=1
+        c1=1
         #Basic info
         for group in info_groups:
             row = toprow
-            c2 = col + group["left_span"]
+            c2 = c1 + group["left_span"]
             for info in group["info"]:
-                worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
+                worksheet.merge_range(row,c1,row,c2-1,info["label"],basic_h_format)
                 if info["label"] == "Date:":
                     worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
                 else:
                     worksheet.write(row,c2,info["data"],basic_format)
                 row += 1
             bottomrow = max(row, bottomrow)
-            col = c2 + group["right_span"]
+            c1 = c2 + group["right_span"]
         toprow += bottomrow+2
 
         #Election tables

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -221,6 +221,8 @@ def simulation_to_xlsx(simulation, filename):
         parties     = simulation.e_rules[r]["parties"           ] + ["Total"]
 
         basic_info = [
+            {"label": "Date:",
+                "data": datetime.now()},
             {"label": "Reference votes:",
                 "data": simulation.vote_table_name},
             {"label": "Electoral system:",
@@ -275,37 +277,43 @@ def simulation_to_xlsx(simulation, filename):
         }
         toprow = 0
         bottomrow = toprow
+        col=1
         #Basic info
         row=toprow
-        col=1
         span=3
         c2=col+span
-        worksheet.merge_range(row,col,row,c2-1,"Date:",basic_h_format)
-        worksheet.merge_range(row,c2,row,c2+1,datetime.now(),time_format)
-        row += 1
         for info in basic_info:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            worksheet.write(row,c2,info["data"],basic_format)
+            if info["label"] == "Date:":
+                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
+            else:
+                worksheet.write(row,c2,info["data"],basic_format)
             row += 1
         bottomrow = max(row, bottomrow)
+        col+=span+5
 
         row=toprow
-        col+=span+5
         span=6
         c2=col+span
         for info in election_settings:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            worksheet.write(row,c2,info["data"],basic_format)
+            if info["label"] == "Date:":
+                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
+            else:
+                worksheet.write(row,c2,info["data"],basic_format)
             row += 1
         bottomrow = max(row, bottomrow)
+        col+=span+3
 
         row=toprow
-        col+=span+3
         span=3
         c2=col+span
         for info in simulation_settings:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            worksheet.write(row,c2,info["data"],basic_format)
+            if info["label"] == "Date:":
+                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
+            else:
+                worksheet.write(row,c2,info["data"],basic_format)
             row += 1
         bottomrow = max(row, bottomrow)
 

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -258,15 +258,15 @@ def simulation_to_xlsx(simulation, filename):
         #Basic info
         row=toprow
         col=1
-        span=4
+        span=3
         cr=col+span
         worksheet.merge_range(row,col,row,cr-1,"Date:",basic_h_format)
         worksheet.merge_range(row,cr,row,cr+1,datetime.now(),time_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Vote data being used:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Reference votes:",basic_h_format)
         worksheet.write(row,cr,simulation.vote_table_name,basic_format)
         row += 1
-        worksheet.merge_range(row,col,row,cr-1,"Electoral system being used:",basic_h_format)
+        worksheet.merge_range(row,col,row,cr-1,"Electoral system:",basic_h_format)
         worksheet.write(row,cr,simulation.e_rules[r]["name"],basic_format)
         row += 1
         worksheet.merge_range(row,col,row,cr-1,"Adjustment method:",basic_h_format)

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -8,6 +8,48 @@ from dictionaries import ADJUSTMENT_METHOD_NAMES as AMN, \
                          DIVIDER_RULE_NAMES as DRN, \
                          GENERATING_METHOD_NAMES as GMN
 
+def prepare_formats(workbook):
+    formats = {}
+    formats["cell"] = workbook.add_format()
+    formats["cell"].set_align('right')
+
+    formats["share"] = workbook.add_format()
+    formats["share"].set_num_format('0.0%')
+
+    formats["h"] = workbook.add_format()
+    formats["h"].set_align('center')
+    formats["h"].set_bold()
+    formats["h"].set_font_size(14)
+
+    formats["time"] = workbook.add_format()
+    formats["time"].set_num_format('d mmm yyyy hh:mm')
+    formats["time"].set_align('left')
+
+    formats["basic"] = workbook.add_format()
+    formats["basic"].set_align('left')
+
+    formats["basic_h"] = workbook.add_format()
+    formats["basic_h"].set_align('right')
+    formats["basic_h"].set_bold()
+    formats["basic_h"].set_font_size(12)
+
+    #simulations
+    formats["r"] = workbook.add_format()
+    formats["r"].set_rotation(90)
+    formats["r"].set_align('center')
+    formats["r"].set_align('vcenter')
+    formats["r"].set_text_wrap()
+    formats["r"].set_bold()
+    formats["r"].set_font_size(12)
+
+    formats["base"] = workbook.add_format()
+    formats["base"].set_num_format('#,##0')
+
+    formats["sim"] = workbook.add_format()
+    formats["sim"].set_num_format('#,##0.000')
+
+    return formats
+
 def write_matrix(worksheet, startrow, startcol, matrix, cformat):
     for c in range(len(matrix)):
         for p in range(len(matrix[c])):
@@ -39,26 +81,8 @@ def election_to_xlsx(election, filename):
     xtd_final_shares = find_xtd_shares([xtd_final_votes])[0]
 
     workbook = xlsxwriter.Workbook(filename)
+    fmt = prepare_formats(workbook)
     worksheet = workbook.add_worksheet()
-    cell_format = workbook.add_format()
-    cell_format.set_align('right')
-    share_format = workbook.add_format()
-    share_format.set_num_format('0.0%')
-    h_format = workbook.add_format()
-    h_format.set_align('center')
-    h_format.set_bold()
-    h_format.set_font_size(14)
-
-    time_format = workbook.add_format()
-    time_format.set_num_format('d mmm yyyy hh:mm')
-
-    basic_format = workbook.add_format()
-    basic_format.set_align('left')
-
-    basic_h_format = workbook.add_format()
-    basic_h_format.set_align('right')
-    basic_h_format.set_bold()
-    basic_h_format.set_font_size(12)
 
     worksheet.set_column('B:B', 20)
 
@@ -66,18 +90,18 @@ def election_to_xlsx(election, filename):
         heading, xheaders, yheaders,
         matrix,
         topleft="Constituency",
-        cformat=cell_format
+        cformat=fmt["cell"]
     ):
         if heading.endswith("shares"):
-            cformat = share_format
+            cformat = fmt["share"]
         worksheet.merge_range(
             row, col+1,
             row, col+len(xheaders),
-            heading, h_format
+            heading, fmt["h"]
         )
-        worksheet.write(row+1, col, topleft, cell_format)
-        worksheet.write_row(row+1, col+1, xheaders, cell_format)
-        worksheet.write_column(row+2, col, yheaders, cell_format)
+        worksheet.write(row+1, col, topleft, fmt["cell"])
+        worksheet.write_row(row+1, col+1, xheaders, fmt["cell"])
+        worksheet.write_column(row+2, col, yheaders, fmt["cell"])
         write_matrix(worksheet, row+2, col+1, matrix, cformat)
 
     startcol = 1
@@ -86,11 +110,11 @@ def election_to_xlsx(election, filename):
     c1=1
     left_span=2
     c2=c1+left_span
-    worksheet.merge_range(toprow,c1,toprow,c2-1,"Date:",basic_h_format)
-    worksheet.merge_range(toprow,c2,toprow,c2+1,datetime.now(),time_format)
+    worksheet.merge_range(toprow,c1,toprow,c2-1,"Date:",fmt["basic_h"])
+    worksheet.merge_range(toprow,c2,toprow,c2+1,datetime.now(),fmt["time"])
     toprow+=1
-    worksheet.merge_range(toprow,c1,toprow,c2-1,"Test name:",basic_h_format)
-    worksheet.write(toprow,c2,"My electoral system",basic_format)
+    worksheet.merge_range(toprow,c1,toprow,c2-1,"Test name:",fmt["basic_h"])
+    worksheet.write(toprow,c2,"My electoral system",fmt["basic"])
 
     startrow = 4
     tables_before = [
@@ -110,8 +134,8 @@ def election_to_xlsx(election, filename):
                    'Vote shares above threshold', 'Constituency seats']
     matrix = [xtd_votes[-1],   xtd_shares[-1],   [threshold],
               xtd_final_votes, xtd_final_shares, xtd_const_seats[-1]]
-    formats = [cell_format, share_format, share_format,
-               cell_format, share_format, cell_format]
+    formats = [fmt["cell"], fmt["share"], fmt["share"],
+               fmt["cell"], fmt["share"], fmt["cell"]]
     draw_block(worksheet, row=startrow, col=startcol,
         heading="Adjustment seat apportionment", topleft="Party",
         xheaders=parties, yheaders=row_headers,
@@ -125,11 +149,11 @@ def election_to_xlsx(election, filename):
         worksheet.merge_range(
             startrow, startcol+1,
             startrow, startcol+len(parties),
-            "Step-by-step demonstration", h_format
+            "Step-by-step demonstration", fmt["h"]
         )
-        worksheet.write_row(startrow+1, 1, h, cell_format)
+        worksheet.write_row(startrow+1, 1, h, fmt["cell"])
         for i in range(len(data)):
-            worksheet.write_row(startrow+2+i, 1, data[i], cell_format)
+            worksheet.write_row(startrow+2+i, 1, data[i], fmt["cell"])
         startrow += 3 + len(data)
     except AttributeError:
         pass
@@ -146,8 +170,8 @@ def election_to_xlsx(election, filename):
         )
         startrow += 3 + len(const_names)
 
-    worksheet.write(startrow, startcol, 'Entropy:', h_format)
-    worksheet.write(startrow, startcol+1, election.entropy(), cell_format)
+    worksheet.write(startrow, startcol, 'Entropy:', fmt["h"])
+    worksheet.write(startrow, startcol+1, election.entropy(), fmt["cell"])
 
     workbook.close()
 
@@ -155,66 +179,29 @@ def election_to_xlsx(election, filename):
 def simulation_to_xlsx(simulation, filename):
     """Write detailed information about a simulation to an xlsx file."""
     workbook = xlsxwriter.Workbook(filename)
-
-    r_format = workbook.add_format()
-    r_format.set_rotation(90)
-    r_format.set_align('center')
-    r_format.set_align('vcenter')
-    r_format.set_text_wrap()
-    r_format.set_bold()
-    r_format.set_font_size(12)
-
-    h_format = workbook.add_format()
-    h_format.set_align('center')
-    h_format.set_bold()
-    h_format.set_font_size(14)
-
-    cell_format = workbook.add_format()
-    cell_format.set_align('right')
-
-    base_format = workbook.add_format()
-    base_format.set_num_format('#,##0')
-
-    sim_format = workbook.add_format()
-    sim_format.set_num_format('#,##0.000')
-
-    share_format = workbook.add_format()
-    share_format.set_num_format('0.0%')
-
-    time_format = workbook.add_format()
-    time_format.set_num_format('d mmm yyyy hh:mm')
-    time_format.set_align('left')
-
-    basic_format = workbook.add_format()
-    basic_format.set_align('left')
-
-    basic_h_format = workbook.add_format()
-    basic_h_format.set_align('right')
-    basic_h_format.set_bold()
-    basic_h_format.set_font_size(12)
-
+    fmt = prepare_formats(workbook)
 
     def draw_block(worksheet, row, col,
         heading, xheaders, yheaders,
         matrix,
-        cformat=cell_format
+        cformat=fmt["cell"]
     ):
         if heading.endswith("shares"):
-            cformat = share_format
+            cformat = fmt["share"]
         if heading == "Votes":
-            cformat = base_format
+            cformat = fmt["base"]
         worksheet.merge_range(
-            row, col, row, col+len(xheaders), heading, h_format)
-        worksheet.write_row(row+1, col+1, xheaders, cell_format)
-        worksheet.write_column(row+2, col, yheaders, cell_format)
+            row, col, row, col+len(xheaders), heading, fmt["h"])
+        worksheet.write_row(row+1, col+1, xheaders, fmt["cell"])
+        worksheet.write_column(row+2, col, yheaders, fmt["cell"])
         write_matrix(worksheet, row+2, col+1, matrix, cformat)
 
     categories = [
-        {"abbr": "base", "cell_format": base_format,
+        {"abbr": "base", "cell_format": fmt["base"],
          "heading": "Reference data"                     },
-        {"abbr": "avg",  "cell_format": sim_format,
+        {"abbr": "avg",  "cell_format": fmt["sim"],
          "heading": "Averages from simulation"           },
-        {"abbr": "std",  "cell_format": sim_format,
+        {"abbr": "std",  "cell_format": fmt["sim"],
          "heading": "Standard deviations from simulation"},
     ]
     tables = [
@@ -299,11 +286,11 @@ def simulation_to_xlsx(simulation, filename):
             row = toprow
             c2 = c1 + group["left_span"]
             for info in group["info"]:
-                worksheet.merge_range(row,c1,row,c2-1,info["label"],basic_h_format)
+                worksheet.merge_range(row,c1,row,c2-1,info["label"],fmt["basic_h"])
                 if info["label"] == date_label:
-                    worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
+                    worksheet.merge_range(row,c2,row,c2+1,info["data"],fmt["time"])
                 else:
-                    worksheet.write(row,c2,info["data"],basic_format)
+                    worksheet.write(row,c2,info["data"],fmt["basic"])
                 row += 1
             bottomrow = max(row, bottomrow)
             c1 = c2 + group["right_span"]
@@ -312,7 +299,7 @@ def simulation_to_xlsx(simulation, filename):
         #Election tables
         for category in categories:
             worksheet.merge_range(toprow, 0, toprow+1+len(const_names), 0,
-                category["heading"], r_format)
+                category["heading"], fmt["r"])
             col = 2
             for table in tables:
                 draw_block(worksheet, row=toprow, col=col,
@@ -343,7 +330,7 @@ def simulation_to_xlsx(simulation, filename):
             xheaders=aggregate_names,
             yheaders=measure_names,
             matrix=measure_table,
-            cformat=sim_format
+            cformat=fmt["sim"]
         )
 
     workbook.close()

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -52,6 +52,14 @@ def election_to_xlsx(election, filename):
     time_format = workbook.add_format()
     time_format.set_num_format('d mmm yyyy hh:mm')
 
+    basic_format = workbook.add_format()
+    basic_format.set_align('left')
+
+    basic_h_format = workbook.add_format()
+    basic_h_format.set_align('right')
+    basic_h_format.set_bold()
+    basic_h_format.set_font_size(12)
+
     worksheet.set_column('B:B', 20)
 
     def draw_block(worksheet, row, col,
@@ -75,10 +83,14 @@ def election_to_xlsx(election, filename):
     startcol = 1
 
     toprow=0
-    worksheet.merge_range(toprow,0,toprow,1,"Test name:",h_format)
-    worksheet.merge_range(toprow,2,toprow,3,"My electoral system",cell_format)
-    worksheet.merge_range(toprow+1,0,toprow+1,1,"Date:",h_format)
-    worksheet.merge_range(toprow+1,2,toprow+1,3,datetime.now(),time_format)
+    c1=1
+    left_span=2
+    c2=c1+left_span
+    worksheet.merge_range(toprow,c1,toprow,c2-1,"Date:",basic_h_format)
+    worksheet.merge_range(toprow,c2,toprow,c2+1,datetime.now(),time_format)
+    toprow+=1
+    worksheet.merge_range(toprow,c1,toprow,c2-1,"Test name:",basic_h_format)
+    worksheet.write(toprow,c2,"My electoral system",basic_format)
 
     startrow = 4
     tables_before = [

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -291,14 +291,18 @@ def simulation_to_xlsx(simulation, filename):
         col+=span+3
         span=3
         c2=col+span
-        worksheet.merge_range(row,col,row,c2-1,"Number of simulations:",basic_h_format)
-        worksheet.write(row,c2,simulation.num_total_simulations,basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Generating method:",basic_h_format)
-        worksheet.write(row,c2,GMN[simulation.variate],basic_format)
-        row += 1
-        worksheet.merge_range(row,col,row,c2-1,"Stability parameter:",basic_h_format)
-        worksheet.write(row,c2,simulation.stbl_param,basic_format)
+        simulation_settings = [
+            {"label": "Number of simulations:",
+                "data": simulation.num_total_simulations},
+            {"label": "Generating method:",
+                "data": GMN[simulation.variate]},
+            {"label": "Stability parameter:",
+                "data": simulation.stbl_param},
+        ]
+        for info in simulation_settings:
+            worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
+            worksheet.write(row,c2,info["data"],basic_format)
+            row += 1
 
         padding=2
         toprow += 4+padding

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -252,9 +252,10 @@ def simulation_to_xlsx(simulation, filename):
         col=1
         span=3
         c2=col+span
+        worksheet.merge_range(row,col,row,c2-1,"Date:",basic_h_format)
+        worksheet.merge_range(row,c2,row,c2+1,datetime.now(),time_format)
+        row += 1
         basic_info = [
-            {"label": "Date:",
-                "data": datetime.now()},
             {"label": "Reference votes:",
                 "data": simulation.vote_table_name},
             {"label": "Electoral system:",
@@ -264,10 +265,7 @@ def simulation_to_xlsx(simulation, filename):
         ]
         for info in basic_info:
             worksheet.merge_range(row,col,row,c2-1,info["label"],basic_h_format)
-            if info["label"] == "Date:":
-                worksheet.merge_range(row,c2,row,c2+1,info["data"],time_format)
-            else:
-                worksheet.write(row,c2,info["data"],basic_format)
+            worksheet.write(row,c2,info["data"],basic_format)
             row += 1
 
         row=toprow

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -97,7 +97,7 @@ class SimulationRules(Rules):
 
 class Simulation:
     """Simulate a set of elections."""
-    def __init__(self, sim_rules, e_rules, m_votes, stbl_param=100):
+    def __init__(self, sim_rules, e_rules, m_votes, table_name, stbl_param=100):
         self.num_total_simulations = sim_rules["simulation_count"]
         self.num_rulesets = len(e_rules)
         self.num_constituencies = len(m_votes)
@@ -112,6 +112,7 @@ class Simulation:
         ]))
         self.sim_rules = sim_rules
         self.e_rules = e_rules
+        self.vote_table_name = table_name
         self.base_votes = m_votes
         self.xtd_votes = add_totals(self.base_votes)
         self.xtd_vote_shares = find_xtd_shares(self.xtd_votes)

--- a/backend/tests/divisors.py
+++ b/backend/tests/divisors.py
@@ -68,8 +68,7 @@ class TestDivisors(unittest.TestCase):
         self.assertEqual(next(gen), math.sqrt(3*4)*base)
         self.assertEqual(next(gen), math.sqrt(4*5)*base)
         for i in range(1000):
-            next(gen)
-        self.assertGreater(1/first, 1/next(gen))
+            self.assertGreater(1/first, 1/next(gen))
 
 class TestApportionment1d(unittest.TestCase):
 

--- a/backend/tests/divisors.py
+++ b/backend/tests/divisors.py
@@ -69,7 +69,7 @@ class TestDivisors(unittest.TestCase):
         self.assertEqual(next(gen), math.sqrt(4*5)*base)
         for i in range(1000):
             next(gen)
-        self.assertGreater(first, next(gen))
+        self.assertGreater(1/first, 1/next(gen))
 
 class TestApportionment1d(unittest.TestCase):
 

--- a/backend/tests/measures.py
+++ b/backend/tests/measures.py
@@ -27,7 +27,7 @@ class MeasureTest(TestCase):
         election = voting.Election(self.e_rules, self.votes)
         comparison_rules = self.e_rules.generate_all_adj_ruleset()
         comparison_election = voting.Election(comparison_rules, self.votes)
-        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes)
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, '')
 
         #Act
         base_results = election.run()
@@ -65,7 +65,7 @@ class MeasureTest(TestCase):
         comparison_rules = self.e_rules.generate_one_const_ruleset()
         v_votes = [sum(x) for x in zip(*self.votes)]
         comparison_election = voting.Election(comparison_rules, [v_votes])
-        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes)
+        sim = simulate.Simulation(self.s_rules, [self.e_rules], self.votes, '')
 
         #Act
         base_results = election.run()

--- a/backend/util.py
+++ b/backend/util.py
@@ -8,6 +8,7 @@ import os
 import openpyxl
 import configparser
 import codecs
+from distutils.util import strtobool
 
 from methods import var_alt_scal, alternating_scaling, icelandic_law
 from methods import monge, nearest_neighbor, relative_superiority
@@ -91,6 +92,12 @@ def parse_input(
     name_included=False,
     filename=''
 ):
+    name_included = strtobool(str(name_included))
+    parties_included = strtobool(str(parties_included))
+    const_included = strtobool(str(const_included))
+    const_seats_included = strtobool(str(const_seats_included))
+    adj_seats_included = strtobool(str(adj_seats_included))
+
     res = {}
     table_name = ''
     if name_included or parties_included:

--- a/backend/util.py
+++ b/backend/util.py
@@ -113,6 +113,28 @@ def parse_input(
             res["parties"] = res["parties"][:-1]
         res["votes"] = [row[:len(res["parties"])] for row in res["votes"]]
     res["votes"] = [[parsint(v) for v in row] for row in res["votes"]]
+
+    #Make sure data is not malformed
+    num_constituencies = len(res["votes"])
+    num_parties = len(res["votes"][0])
+    assert(all([len(row) == num_parties for row in res["votes"]]))
+    if parties_included:
+        assert(len(res["parties"]) == num_parties)
+    else:
+        res["parties"] = ['']*num_parties
+    if const_included:
+        assert(len(res["constituencies"]) == num_constituencies)
+    else:
+        res["constituencies"] = ['']*num_constituencies
+    if const_seats_included:
+        assert(len(res["constituency_seats"]) == num_constituencies)
+    else:
+        res["constituency_seats"] = [0]*num_constituencies
+    if adj_seats_included:
+        assert(len(res["constituency_adjustment_seats"]) == num_constituencies)
+    else:
+        res["constituency_adjustment_seats"] = [0]*num_constituencies
+
     return res
 
 def parsint(value):

--- a/backend/util.py
+++ b/backend/util.py
@@ -4,6 +4,7 @@ from backports import csv
 import sys #??????
 from tabulate import tabulate
 import io
+import os
 import openpyxl
 import configparser
 import codecs
@@ -77,7 +78,8 @@ def load_votes_from_stream(stream, filename):
         parties_included=True,
         const_included=True,
         const_seats_included=const_seats_incl,
-        adj_seats_included=adj_seats_incl
+        adj_seats_included=adj_seats_incl,
+        filename=filename
     )
 
 def parse_input(
@@ -85,12 +87,15 @@ def parse_input(
     parties_included,
     const_included,
     const_seats_included,
-    adj_seats_included
+    adj_seats_included,
+    filename=''
 ):
     res = {}
     if parties_included:
         res["parties"] = input[0]
         del(input[0])
+
+    res["table_name"] = determine_table_name(filename)
 
     if const_included:
         res["constituencies"] = [row[0] for row in input]
@@ -140,6 +145,8 @@ def parse_input(
 def parsint(value):
     return int(value) if value else 0
 
+def determine_table_name(filename):
+    return os.path.splitext(filename)[0]
 
 def load_votes(votefile, consts):
     """Load votes from a file."""

--- a/backend/util.py
+++ b/backend/util.py
@@ -76,6 +76,7 @@ def load_votes_from_stream(stream, filename):
 
     return parse_input(
         input=rd,
+        name_included=False,
         parties_included=True,
         const_included=True,
         const_seats_included=const_seats_incl,
@@ -85,11 +86,11 @@ def load_votes_from_stream(stream, filename):
 
 def parse_input(
     input,
+    name_included,
     parties_included,
     const_included,
     const_seats_included,
     adj_seats_included,
-    name_included=False,
     filename=''
 ):
     name_included = strtobool(str(name_included))

--- a/backend/util.py
+++ b/backend/util.py
@@ -58,6 +58,8 @@ def load_constituencies(confile):
 def load_votes_from_stream(stream, filename):
     rd = []
     if filename.endswith(".csv"):
+        if isinstance(stream, io.TextIOWrapper) and stream.encoding != 'utf-8':
+            stream.reconfigure(encoding='utf-8')
         if isinstance(stream, io.BytesIO):
             stream = codecs.iterdecode(stream, 'utf-8')
         for row in csv.reader(stream, skipinitialspace=True):

--- a/backend/util.py
+++ b/backend/util.py
@@ -88,17 +88,23 @@ def parse_input(
     const_included,
     const_seats_included,
     adj_seats_included,
+    name_included=False,
     filename=''
 ):
     res = {}
-    if parties_included:
-        res["parties"] = input[0]
+    table_name = ''
+    if name_included or parties_included:
+        if name_included:
+            table_name = input[0][0]
+        if parties_included:
+            res["parties"] = input[0]
         del(input[0])
 
-    res["table_name"] = determine_table_name(filename)
+    res["table_name"] = determine_table_name(table_name,filename)
 
-    if const_included:
-        res["constituencies"] = [row[0] for row in input]
+    if name_included or const_included:
+        if const_included:
+            res["constituencies"] = [row[0] for row in input]
         for row in input: del(row[0])
         if parties_included: res["parties"] = res["parties"][1:]
 
@@ -145,8 +151,8 @@ def parse_input(
 def parsint(value):
     return int(value) if value else 0
 
-def determine_table_name(filename):
-    return os.path.splitext(filename)[0]
+def determine_table_name(first,filename):
+    return first if first else os.path.splitext(filename)[0]
 
 def load_votes(votefile, consts):
     """Load votes from a file."""

--- a/backend/util.py
+++ b/backend/util.py
@@ -72,13 +72,14 @@ def load_votes_from_stream(stream, filename):
     else:
         return None, None, None
 
+    name_incl = rd[0][0].lower() != u"kjördæmi"
     const_seats_incl = rd[0][1].lower() == "cons"
     expected = 2 if const_seats_incl else 1
     adj_seats_incl = rd[0][expected].lower() == "adj"
 
     return parse_input(
         input=rd,
-        name_included=False,
+        name_included=name_incl,
         parties_included=True,
         const_included=True,
         const_seats_included=const_seats_incl,

--- a/backend/web.py
+++ b/backend/web.py
@@ -264,9 +264,11 @@ def set_up_simulation():
     if not "ref_votes" in data:
         return False, "Votes missing."
 
-    for const in data["ref_votes"]:
-        for party in const:
-            if type(party) != int:
+    for c in range(len(data["ref_votes"])):
+        for p in range(len(data["ref_votes"][c])):
+            if not data["ref_votes"][c][p]:
+                data["ref_votes"][c][p] = 0
+            if type(data["ref_votes"][c][p]) != int:
                 return False, "Votes must be numbers."
 
     stability_parameter = 100

--- a/backend/web.py
+++ b/backend/web.py
@@ -275,8 +275,8 @@ def set_up_simulation():
             election_rules[info] = vote_table[info]
 
         for info in ["constituency_seats", "constituency_adjustment_seats"]:
-            if info in data["election_rules"] and data["election_rules"][info]:
-                election_rules[info] = data["election_rules"][info]
+            if info in rs and rs[info]:
+                election_rules[info] = rs[info]
             else:
                 election_rules[info] = vote_table[info]
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -166,7 +166,6 @@ def prepare_to_save_vote_table():
         ] + vote_table["votes"][c]
         for c in range(num_constituencies)
     ]
-    print(file_matrix)
 
     tmpfilename = tempfile.mktemp(prefix='vote_table-')
     save_votes_to_xlsx(file_matrix, tmpfilename)

--- a/backend/web.py
+++ b/backend/web.py
@@ -165,6 +165,7 @@ def start_simulation():
 
     success, simulation = set_up_simulation()
     if not success:
+        print(simulation)
         return jsonify({"started": False, "error": simulation})
 
     # Simulation cache expires in 3 hours = 3*3600 = 10800 seconds

--- a/backend/web.py
+++ b/backend/web.py
@@ -441,7 +441,7 @@ def get_presets_dict():
     from os.path import isfile, join
 
     try:
-        with open('../data/presets.json') as js:
+        with open('../data/presets.json', encoding='utf-8') as js:
             data = json.load(js)
     except IOError:
         data = {'error': 'Could not load presets: database lost.'}

--- a/backend/web.py
+++ b/backend/web.py
@@ -104,6 +104,15 @@ def get_election_excel():
 
 @app.route('/api/votes/save/', methods=['POST'])
 def save_votes():
+    tmpfilename, attachment_filename = prepare_to_save_vote_table()
+    return send_from_directory(
+        directory=os.path.dirname(tmpfilename),
+        filename=os.path.basename(tmpfilename),
+        attachment_filename=attachment_filename,
+        as_attachment=True
+    )
+
+def prepare_to_save_vote_table():
     data = request.get_json(force=True)
     if "vote_table" not in data or not data["vote_table"]:
         return False, f"Missing data (vote_table)"
@@ -138,18 +147,11 @@ def save_votes():
     print(file_matrix)
 
     tmpfilename = tempfile.mktemp(prefix='vote_table-')
-    print(tmpfilename)
-    filename = secure_filename(vote_table['name'])
-    print(filename)
     save_votes_to_xlsx(file_matrix, tmpfilename)
-    attachment_filename = f"{filename}.xlsx"
-    print(attachment_filename)
-    return send_from_directory(
-        directory=os.path.dirname(tmpfilename),
-        filename=os.path.basename(tmpfilename),
-        attachment_filename=f"{filename}.xlsx",
-        as_attachment=True
-    )
+    filename = secure_filename(vote_table['name'])
+    attachment_filename=f"{filename}.xlsx"
+
+    return tmpfilename, attachment_filename
 
 @app.route('/api/votes/upload/', methods=['POST'])
 def upload_votes():

--- a/backend/web.py
+++ b/backend/web.py
@@ -275,7 +275,10 @@ def set_up_simulation():
             election_rules[info] = vote_table[info]
 
         for info in ["constituency_seats", "constituency_adjustment_seats"]:
-            election_rules[info] = vote_table[info]
+            if info in data["election_rules"] and data["election_rules"][info]:
+                election_rules[info] = data["election_rules"][info]
+            else:
+                election_rules[info] = vote_table[info]
 
             for c in range(len(election_rules[info])):
                 if not election_rules[info][c]:

--- a/backend/web.py
+++ b/backend/web.py
@@ -271,8 +271,17 @@ def set_up_simulation():
             print("Setting election_rules[%s] = %s" % (k, v))
             election_rules[k] = v
 
-        for x in ["constituency_names", "constituency_seats", "parties", "constituency_adjustment_seats"]:
-            election_rules[x] = vote_table[x]
+        for info in ["parties", "constituency_names"]:
+            election_rules[info] = vote_table[info]
+
+        for info in ["constituency_seats", "constituency_adjustment_seats"]:
+            election_rules[info] = vote_table[info]
+
+            for c in range(len(election_rules[info])):
+                if not election_rules[info][c]:
+                    election_rules[info][c]=0
+                if type(election_rules[info][c]) != int:
+                    return False, "Seat specifications must be numbers."
 
         rulesets.append(election_rules)
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -121,6 +121,7 @@ def paste_votes():
 
     return jsonify(util.parse_input(
         input=rd,
+        name_included=data["has_name"],
         parties_included=data["has_parties"],
         const_included=data["has_constituencies"],
         const_seats_included=data["has_constituency_seats"],

--- a/backend/web.py
+++ b/backend/web.py
@@ -95,7 +95,8 @@ def get_election_excel():
     return send_from_directory(
         directory=os.path.dirname(tmpfilename),
         filename=os.path.basename(tmpfilename),
-        attachment_filename="election.xlsx",
+        attachment_filename=
+            f"election {datetime.now().strftime('%Y.%m.%d %H.%M.%S')}.xlsx",
         as_attachment=True
     )
 
@@ -233,7 +234,8 @@ def get_xlsx():
     return send_from_directory(
         directory=os.path.dirname(tmpfilename),
         filename=os.path.basename(tmpfilename),
-        attachment_filename="simulation.xlsx",
+        attachment_filename=
+            f"simulation {datetime.now().strftime('%Y.%m.%d %H.%M.%S')}.xlsx",
         as_attachment=True
     )
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -261,6 +261,8 @@ def set_up_simulation():
 
         rulesets.append(election_rules)
 
+    table_name = data["table_name"] if "table_name" in data else ""
+
     if not "ref_votes" in data:
         return False, "Votes missing."
 
@@ -284,7 +286,8 @@ def set_up_simulation():
 
     try:
         simulation = sim.Simulation(
-            simulation_rules, rulesets, data["ref_votes"], stability_parameter)
+            simulation_rules, rulesets, data["ref_votes"], table_name,
+            stability_parameter)
     except ZeroDivisionError:
         return False, "Need to have more votes."
 

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -146,10 +146,11 @@ export default {
         constituency_seats: this.constituency_seats,
         constituency_adjustment_seats: this.constituency_adjustment_seats
       }, {responseType: 'blob'}).then(response => {
+        let dis = response.headers.get("content-disposition")
         let blob = new Blob([response.body], {type: 'file'})
         let link = document.createElement('a')
         link.href = window.URL.createObjectURL(blob)
-        link.download = 'election.xlsx'
+        link.download = dis.substring(dis.indexOf("filename=")+10, dis.length-1)
         link.click()
       }, response => {
         this.server.error = true;

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -145,12 +145,9 @@ export default {
         constituency_names: this.constituency_names,
         constituency_seats: this.constituency_seats,
         constituency_adjustment_seats: this.constituency_adjustment_seats
-      }, {responseType: 'blob'}).then(response => {
-        let dis = response.headers.get("content-disposition")
-        let blob = new Blob([response.body], {type: 'file'})
+      }).then(response => {
         let link = document.createElement('a')
-        link.href = window.URL.createObjectURL(blob)
-        link.download = dis.substring(dis.indexOf("filename=")+10, dis.length-1)
+        link.href = '/api/downloads/get?id=' + response.data.download_id
         link.click()
       }, response => {
         this.server.error = true;

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -267,15 +267,17 @@ export default {
       this.server.waitingForData = true;
       this.$http.post('/api/simulate/',
         {
-          table_name: this.table_name,
-          ref_votes: this.ref_votes,
+          vote_table: {
+            name: this.table_name,
+            constituency_names: this.constituency_names,
+            constituency_seats: this.constituency_seats,
+            constituency_adjustment_seats: this.constituency_adjustment_seats,
+            parties: this.parties,
+            votes: this.ref_votes
+          },
           election_rules: this.election_rules,
           simulation_rules: this.simulation_rules,
-          stbl_param: this.distribution_parameter,
-          parties: this.parties,
-          constituency_names: this.constituency_names,
-          constituency_seats: this.constituency_seats,
-          constituency_adjustment_seats: this.constituency_adjustment_seats
+          stbl_param: this.distribution_parameter
         }).then(response => {
           if (response.body.error) {
             this.server.errormsg = response.body.error;

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -26,6 +26,7 @@
     <h2>Reference votes</h2>
     <p>Reference votes are the votes that will be used as mean values for the statistical distribution in the simulation.</p>
     <VoteMatrix
+      @update-table-name="updateTableName"
       @update-votes="updateVotes"
       @update-adjustment-seats="updateAdjustmentSeats"
       @update-constituency-seats="updateConstituencySeats"
@@ -156,6 +157,7 @@ export default {
       current_iteration: 0,
       iteration_time: 0,
       inflight: 0,
+      table_name: "",
       ref_votes: [],
       results: { measures: [], methods: [], data: [] },
     }
@@ -183,6 +185,9 @@ export default {
     },
     updateDistributionParameter: function(parameter) {
       this.distribution_parameter = parameter
+    },
+    updateTableName: function(name) {
+      this.table_name = name;
     },
     updateVotes: function(votes) {
       this.ref_votes = votes;
@@ -262,6 +267,7 @@ export default {
       this.server.waitingForData = true;
       this.$http.post('/api/simulate/',
         {
+          table_name: this.table_name,
           ref_votes: this.ref_votes,
           election_rules: this.election_rules,
           simulation_rules: this.simulation_rules,

--- a/vue-frontend/src/components/ElectionSettings.vue
+++ b/vue-frontend/src/components/ElectionSettings.vue
@@ -13,22 +13,22 @@
     <b-row>
       <b-col>
         <b-form-group
-          label="Division rule for allocating constituency seats"
-          description="Which division rule should be used to allocate constituency seats to lists within each constituency?">
+          label="Rule for allocating constituency seats"
+          description="Which rule should be used to allocate constituency seats to lists within each constituency?">
           <b-form-select class="mb-3"
             v-model="rules.election_rules.primary_divider"
             :options="rules.capabilities.divider_rules"/>
         </b-form-group>
         <b-form-group
-          label="Division rule for apportioning adjustment seats"
-          description="Which division rule should be used to apportion adjustment seats among parties?">
+          label="Rule for dividing adjustment seats"
+          description="Which rule should be used to divide adjustment seats between parties?">
           <b-form-select class="mb-3"
             v-model="rules.election_rules.adj_determine_divider"
             :options="rules.capabilities.divider_rules"/>
         </b-form-group>
         <b-form-group
-          label="Division rule for allocating adjustment seats"
-          description="Which division rule should be used to allocate adjustment seats to individual lists?">
+          label="Rule for allocating adjustment seats"
+          description="Which rule should be used to allocate adjustment seats to individual lists?">
           <b-form-select class="mb-3"
             v-model="rules.election_rules.adj_alloc_divider"
             :options="rules.capabilities.divider_rules"/>

--- a/vue-frontend/src/components/SimulationSettings.vue
+++ b/vue-frontend/src/components/SimulationSettings.vue
@@ -6,7 +6,7 @@
           <b-form-group
             label="Number of simulations"
             description="How many simulations should be run? Select 0 to use only reference data instead of any simulated data.">
-            <b-form-input type="number" v-model.number="rules.simulation_rules.simulation_count" min="2"/>
+            <b-form-input type="number" v-model.number="rules.simulation_rules.simulation_count" min="0"/>
           </b-form-group>
         </b-col>
         <b-col>

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -236,10 +236,11 @@ export default {
           votes: this.votes
         }
       }, {responseType: 'blob'}).then(response => {
+        let dis = response.headers.get("content-disposition")
         let blob = new Blob([response.body], {type: 'file'})
         let link = document.createElement('a')
         link.href = window.URL.createObjectURL(blob)
-        link.download = 'vote_table.xlsx'
+        link.download = dis.substring(dis.indexOf("filename=")+9)
         link.click()
       }, response => {
         this.server.error = true;

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -107,11 +107,11 @@
 export default {
   data: function () {
     return {
-      table_name: "Test",
       constituencies: ["I", "II"],
       constituency_seats: [10, 10],
       constituency_adjustment_seats: [2, 3],
       parties: ["A", "B"],
+      table_name: "Test",
       votes: [[1500, 2000], [2500, 1700]],
       presets: [],
       presetfields: [
@@ -137,11 +137,17 @@ export default {
     });
     this.$emit('update-constituencies', this.constituencies, false);
     this.$emit('update-parties', this.parties, false);
+    this.$emit('update-table-name', this.table_name, false);
     this.$emit('update-votes', this.votes, false);
     this.$emit('update-constituency-seats', this.constituency_seats, false);
     this.$emit('update-adjustment-seats', this.constituency_adjustment_seats, false);
   },
   watch: {
+    'table_name': {
+      handler: function (val, oldVal) {
+        this.$emit('update-table-name', val);
+      }
+    },
     'votes': {
       handler: function (val, oldVal) {
         this.$emit('update-votes', val);

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -71,7 +71,7 @@
         </b-dropdown-->
       </b-button-group>
       <b-button-group class="mx-1">
-        <b-button disabled>Save voteset</b-button>
+        <b-button @click="saveVotes()">Save voteset</b-button>
       </b-button-group>
     </b-button-toolbar>
     <table class="votematrix">
@@ -224,6 +224,26 @@ export default {
       this.constituency_adjustment_seats = [];
       this.parties = [];
       this.votes = [];
+    },
+    saveVotes: function() {
+      this.$http.post('/api/votes/save/', {
+        vote_table: {
+          name: this.table_name,
+          constituency_names: this.constituencies,
+          constituency_seats: this.constituency_seats,
+          constituency_adjustment_seats: this.constituency_adjustment_seats,
+          parties: this.parties,
+          votes: this.votes
+        }
+      }, {responseType: 'blob'}).then(response => {
+        let blob = new Blob([response.body], {type: 'file'})
+        let link = document.createElement('a')
+        link.href = window.URL.createObjectURL(blob)
+        link.download = 'vote_table.xlsx'
+        link.click()
+      }, response => {
+        this.server.error = true;
+      })
     },
     loadPreset: function(eid) {
       this.$http.post('/api/presets/load/', {'eid': eid}).then(response => {

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -242,6 +242,7 @@ export default {
       });
     },
     handleReceivedVotes(data) {
+      this.table_name = data.table_name;
       this.constituencies = data.constituencies;
       this.parties = data.parties;
       this.votes = data.votes;
@@ -258,6 +259,7 @@ export default {
         return;
       }
       this.$http.post('/api/votes/paste/', this.paste).then(response => {
+        this.table_name = response.data.table_name;
         this.votes = response.data.votes;
         if (response.data.constituencies) {
           this.constituencies = response.data.constituencies;

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -111,7 +111,7 @@ export default {
       constituency_seats: [10, 10],
       constituency_adjustment_seats: [2, 3],
       parties: ["A", "B"],
-      table_name: "Test",
+      table_name: "My reference votes",
       votes: [[1500, 2000], [2500, 1700]],
       presets: [],
       presetfields: [

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -70,8 +70,8 @@
     </b-button-toolbar>
     <table class="votematrix">
       <tr class="parties">
-        <th class="small-12 medium-1 topleft">
-          &nbsp;
+        <th class="small-12 medium-1 tablename">
+          <input type="text" v-model="table_name">
         </th>
         <th>
           <abbr title="Constituency seats"># Cons.</abbr>
@@ -107,6 +107,7 @@
 export default {
   data: function () {
     return {
+      table_name: "Test",
       constituencies: ["I", "II"],
       constituency_seats: [10, 10],
       constituency_adjustment_seats: [2, 3],

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -235,12 +235,9 @@ export default {
           parties: this.parties,
           votes: this.votes
         }
-      }, {responseType: 'blob'}).then(response => {
-        let dis = response.headers.get("content-disposition")
-        let blob = new Blob([response.body], {type: 'file'})
+      }).then(response => {
         let link = document.createElement('a')
-        link.href = window.URL.createObjectURL(blob)
-        link.download = dis.substring(dis.indexOf("filename=")+9)
+        link.href = '/api/downloads/get?id=' + response.data.download_id
         link.click()
       }, response => {
         this.server.error = true;

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -15,6 +15,12 @@
                      rows="7">
       </b-form-textarea>
       <b-form-checkbox
+                     v-model="paste.has_name"
+                     value="true"
+                     unchecked-value="false">
+      First row begins with name by which to refer to this vote table.
+      </b-form-checkbox>
+      <b-form-checkbox
                      v-model="paste.has_parties"
                      value="true"
                      unchecked-value="false">
@@ -122,6 +128,7 @@ export default {
       ],
       uploadfile: null,
       paste: { csv: '',
+               has_name: false,
                has_parties: false,
                has_constituencies: false,
                has_constituency_seats: false,

--- a/vue-frontend/static/css/app.css
+++ b/vue-frontend/static/css/app.css
@@ -40,7 +40,11 @@ th.topleft {
   background-color: #fff;
 }
 
-.constname input {
+.tablename {
+  text-align: center;
+}
+
+.constname input, .tablename input {
   border:         0;
   outline:        0;
   padding:        8px;
@@ -56,8 +60,10 @@ th.topleft {
   background:     none;
 }
 
-.partyvotes input:hover, .partyname input:hover, .constname input:hover,
-.partyvotes input:focus, .partyname input:focus, .constname input:focus {
+.partyvotes input:hover, .partyvotes input:focus,
+.partyname input:hover, .partyname input:focus,
+.constname input:hover, .constname input:focus,
+.tablename input:hover, .tablename input:focus {
   background:     #ddd;
 }
 


### PR DESCRIPTION
- Ensure excel output generation doesn't crash due to different sheets having same name.
- Display information about simulation settings in excel output.
- Timestamp excel output, to distinguish output files.
- Give the vote table a name, and specify in excel output what vote data was used.
- - Read vote table name from upper left corner or filename of uploaded file or loaded preset.
- - Read vote table name from pasted input.
- Add functionality to save vote data to file, so it can be reloaded later.
- Evolve code structure
- Also some minor fixes/improvements