### PR TITLE
Factor out in web interface common elements of Single Election and Simulation

### DIFF
--- a/backend/dictionaries.py
+++ b/backend/dictionaries.py
@@ -47,7 +47,7 @@ ADJUSTMENT_METHODS = {
     "pure-vote-ratios": pure_vote_ratios_apportionment,
 }
 ADJUSTMENT_METHOD_NAMES = {
-    "alternating-scaling": "Alternating-Scaling Method",
+    "alternating-scaling": "Optimal method (Alternating-Scaling)",
     "relative-superiority": "Relative Superiority Method",
     "nearest-neighbor": "Nearest Neighbor Method",
     "monge": "Monge algorithm",

--- a/backend/dictionaries.py
+++ b/backend/dictionaries.py
@@ -28,7 +28,7 @@ DIVIDER_RULE_NAMES = {
     "dhondt": "D'Hondt's method",
     "sainte-lague": "Sainte-Laguë method",
     "nordic": "Nordic Sainte-Laguë variant",
-    "imperiali": "Imeriali method",
+    "imperiali": "Imperiali method",
     "danish": "Danish method",
     "huntington-hill": "Huntington-Hill method",
 }

--- a/backend/electionRules.py
+++ b/backend/electionRules.py
@@ -48,9 +48,8 @@ class ElectionRules(Rules):
         if key == "constituencies":
             value = load_constituencies(value)
             self["constituency_names"] = [x["name"] for x in value]
-            self["constituency_seats"] = [x["num_constituency_seats"]
-                                          for x in value]
-            self["constituency_adjustment_seats"] = [x["num_adjustment_seats"]
+            self["constituency_seats"] = [x["num_const_seats"] for x in value]
+            self["constituency_adjustment_seats"] = [x["num_adj_seats"]
                                                      for x in value]
 
         super(ElectionRules, self).__setitem__(key, value)

--- a/backend/electionRules.py
+++ b/backend/electionRules.py
@@ -34,6 +34,7 @@ class ElectionRules(Rules):
         self["adjustment_threshold"] = 5
         self["adjustment_method"] = "icelandic-law"
         self["constituencies"] = []
+        self["parties"] = []
 
         # Display rules
         self["debug"] = False

--- a/backend/electionRules.py
+++ b/backend/electionRules.py
@@ -19,7 +19,8 @@ class ElectionRules(Rules):
             "adjustment_method": ADJUSTMENT_METHODS.keys(),
         }
         self.range_rules = {
-            "adjustment_threshold": [0, 100]
+            "adjustment_threshold": [0, 100],
+            "constituency_threshold": [0, 100],
         }
         self.list_rules = [
             "constituencies", "parties"
@@ -32,6 +33,7 @@ class ElectionRules(Rules):
         self["adj_determine_divider"] = "dhondt"
         self["adj_alloc_divider"] = "dhondt"
         self["adjustment_threshold"] = 5
+        self["constituency_threshold"] = 0
         self["adjustment_method"] = "icelandic-law"
         self["constituencies"] = []
         self["parties"] = []

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -64,10 +64,7 @@ def write_matrix(worksheet, startrow, startcol, matrix, cformat):
 
 def election_to_xlsx(election, filename):
     """Write detailed information about a single election to an xlsx file."""
-    if "constituencies" in election.rules:
-        const_names = [c["name"] for c in election.rules["constituencies"]]
-    else:
-        const_names = election.rules["constituency_names"]
+    const_names = [c["name"] for c in election.rules["constituencies"]]
     const_names.append("Total")
     parties = election.rules["parties"] + ["Total"]
     xtd_votes = add_totals(election.m_votes)
@@ -216,8 +213,10 @@ def simulation_to_xlsx(simulation, filename):
     for r in range(len(simulation.e_rules)):
         sheet_name  = f'{r+1}-{simulation.e_rules[r]["name"]}'
         worksheet   = workbook.add_worksheet(sheet_name)
-        const_names = simulation.e_rules[r]["constituency_names"] + ["Total"]
-        parties     = simulation.e_rules[r]["parties"           ] + ["Total"]
+        const_names = [
+            const["name"] for const in simulation.e_rules[r]["constituencies"]
+        ] + ["Total"]
+        parties = simulation.e_rules[r]["parties"] + ["Total"]
 
         data_matrix = {
             "base": {
@@ -300,9 +299,9 @@ def simulation_to_xlsx(simulation, filename):
             heading="Desired number of seats",
             xheaders=["cons", "adj", "total"],
             yheaders=const_names,
-            matrix=add_totals([[simulation.e_rules[r]["constituency_seats"][c],
-                     simulation.e_rules[r]["constituency_adjustment_seats"][c]]
-                for c in range(simulation.num_constituencies)])
+            matrix=add_totals([
+                [const["num_const_seats"],const["num_adj_seats"]]
+                for const in simulation.e_rules[r]["constituencies"]])
         )
         bottomrow = max(2+len(const_names), bottomrow)
         toprow += bottomrow+2

--- a/backend/excel_util.py
+++ b/backend/excel_util.py
@@ -111,7 +111,7 @@ def election_to_xlsx(election, filename):
     worksheet.merge_range(toprow,c2,toprow,c2+1,datetime.now(),fmt["time"])
     toprow+=1
     worksheet.merge_range(toprow,c1,toprow,c2-1,"Test name:",fmt["basic_h"])
-    worksheet.write(toprow,c2,"My electoral system",fmt["basic"])
+    worksheet.write(toprow,c2,election.name,fmt["basic"])
 
     startrow = 4
     tables_before = [

--- a/backend/methods/alternating_scaling.py
+++ b/backend/methods/alternating_scaling.py
@@ -16,7 +16,7 @@ def alternating_scaling(m_votes, v_total_seats, v_party_seats,
         - m_prior_allocations: A matrix of where parties have previously
             gotten seats
         - divisor_gen: A generator function generating divisors, e.g. d'Hondt
-        - threshold: A cutoff threshold for participation.
+        - threshold: A cutoff threshold for participation, between 0 and 100.
     """
     m_allocations = deepcopy(m_prior_allocations)
 

--- a/backend/methods/icelandic_law.py
+++ b/backend/methods/icelandic_law.py
@@ -36,7 +36,7 @@ def icelandic_apportionment(m_votes, v_total_seats, v_party_seats,
     seats_info = []
     while num_allocated < total_seats:
         alloc, d = apportion1d(v_votes, num_allocated+1, v_last_alloc,
-                                divisor_gen, invalid)
+                                divisor_gen, invalid=invalid)
         # 2.6.
         #   (Hafi allar hlutfallstölur stjórnmálasamtaka verið numdar brott
         #   skal jafnframt fella niður allar landstölur þeirra.)

--- a/backend/methods/icelandic_law.py
+++ b/backend/methods/icelandic_law.py
@@ -95,7 +95,7 @@ def print_seats(rules, adj_seats_info):
     data = []
     for i in range(len(adj_seats_info)):
         data.append([i+1,
-                    rules["constituency_names"][adj_seats_info[i][0]],
+                    rules["constituencies"][adj_seats_info[i][0]]["name"],
                     adj_seats_info[i][1],
                     rules["parties"][adj_seats_info[i][2]],
                     "{:.3%}".format(adj_seats_info[i][3])])

--- a/backend/methods/var_alt_scal.py
+++ b/backend/methods/var_alt_scal.py
@@ -16,7 +16,7 @@ def var_alt_scal(m_votes, v_total_seats, v_party_seats,
         - m_prior_allocations: A matrix of where parties have previously
             gotten seats
         - divisor_gen: A generator function generating divisors, e.g. d'Hondt
-        - threshold: A cutoff threshold for participation.
+        - threshold: A cutoff threshold for participation, between 0 and 100.
     """
     m_allocations = deepcopy(m_prior_allocations)
 

--- a/backend/simulate.py
+++ b/backend/simulate.py
@@ -104,9 +104,7 @@ class Simulation:
         self.num_parties = len(m_votes[0])
         assert(all([len(c) == self.num_parties for c in m_votes]))
         assert(all([
-            self.num_constituencies == len(ruleset["constituency_names"])
-            and self.num_constituencies == len(ruleset["constituency_seats"])
-            and self.num_constituencies == len(ruleset["constituency_adjustment_seats"])
+            self.num_constituencies == len(ruleset["constituencies"])
             and self.num_parties == len(ruleset["parties"])
             for ruleset in e_rules
         ]))

--- a/backend/table_util.py
+++ b/backend/table_util.py
@@ -28,7 +28,12 @@ def find_xtd_shares(xtd_table):
     return [[float(v)/c[-1] if c[-1]!=0 else 0 for v in c] for c in xtd_table]
 
 def find_shares(table):
-    return [[float(v)/sum(c) if sum(c)!=0 else 0 for v in c] for c in table]
+    return [find_shares_1d(c) for c in table]
+
+def find_shares_1d(v_votes):
+    assert all(v>=0 for v in v_votes), f"negative values detected in {v_votes}"
+    s = sum(v_votes)
+    return [float(v)/s for v in v_votes] if s!=0 else v_votes
 
 def entropy(votes, allocations, divisor_gen):
     """

--- a/backend/tests/basic.py
+++ b/backend/tests/basic.py
@@ -41,9 +41,10 @@ class TestRules(unittest.TestCase):
 class TestBasicAllocation(unittest.TestCase):
     def test_election_basic(self):
         rules = ElectionRules()
-        rules["constituency_seats"] = [1, 2]
-        rules["constituency_adjustment_seats"] = [2, 1]
-        rules["constituency_names"] = ["I", "II"]
+        rules["constituencies"] = [
+            {"name": "I",  "num_const_seats": 1, "num_adj_seats": 2},
+            {"name": "II", "num_const_seats": 2, "num_adj_seats": 1}
+        ]
         rules["parties"] = ["A", "B"]
 
         votes = [[501, 400], [301, 200]]
@@ -53,9 +54,10 @@ class TestBasicAllocation(unittest.TestCase):
 
     def test_election_basic2(self):
         rules = ElectionRules()
-        rules["constituency_seats"] = [1, 1]
-        rules["constituency_adjustment_seats"] = [1, 1]
-        rules["constituency_names"] = ["I", "II"]
+        rules["constituencies"] = [
+            {"name": "I",  "num_const_seats": 1, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 1, "num_adj_seats": 1}
+        ]
         rules["parties"] = ["A", "B", "C"]
         rules["divisor"] = "dhondt"
         rules["adjustment_threshold"] = 0.0

--- a/backend/tests/election.py
+++ b/backend/tests/election.py
@@ -9,9 +9,10 @@ class TestElection(unittest.TestCase):
         rules = ElectionRules()
         rules["parties"] = ["A", "B"]
         rules["adjustment_method"] = "alternating-scaling"
-        rules["constituency_names"] = ["I", "II"]
-        rules["constituency_seats"] = [2, 3]
-        rules["constituency_adjustment_seats"] = [1, 2]
+        rules["constituencies"] = [
+            {"name": "I",  "num_const_seats": 2, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 3, "num_adj_seats": 2}
+        ]
         votes = [[500, 400],[300, 200]]
         election = Election(rules, votes)
         election.run()

--- a/backend/tests/electionRules.py
+++ b/backend/tests/electionRules.py
@@ -13,9 +13,10 @@ class TestElectionRules(TestCase):
         self.rules["adj_alloc_divider"] = "nordic"
         self.rules["adjustment_threshold"] = 4
         self.rules["parties"] = ["A", "B"]
-        self.rules["constituency_names"] = ["I", "II"]
-        self.rules["constituency_seats"] = [2, 3]
-        self.rules["constituency_adjustment_seats"] = [1, 2]
+        self.rules["constituencies"] = [
+            {"name": "I",  "num_const_seats": 2, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 3, "num_adj_seats": 2}
+        ]
         #self.votes = [[500, 400],[300, 200]]
 
     def test_generate_opt_ruleset(self):
@@ -26,9 +27,10 @@ class TestElectionRules(TestCase):
         self.assertEqual(opt["adj_alloc_divider"], "nordic")
         self.assertEqual(opt["adjustment_threshold"], 4)
         self.assertEqual(opt["parties"], ["A", "B"])
-        self.assertEqual(opt["constituency_names"], ["I", "II"])
-        self.assertEqual(opt["constituency_seats"], [2, 3])
-        self.assertEqual(opt["constituency_adjustment_seats"], [1, 2])
+        self.assertEqual(opt["constituencies"], [
+            {"name": "I",  "num_const_seats": 2, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 3, "num_adj_seats": 2}
+        ])
 
     def test_generate_law_ruleset(self):
         law = self.rules.generate_law_ruleset()
@@ -38,9 +40,10 @@ class TestElectionRules(TestCase):
         self.assertEqual(law["adj_alloc_divider"], "dhondt")
         self.assertEqual(law["adjustment_threshold"], 5)
         self.assertEqual(law["parties"], ["A", "B"])
-        self.assertEqual(law["constituency_names"], ["I", "II"])
-        self.assertEqual(law["constituency_seats"], [2, 3])
-        self.assertEqual(law["constituency_adjustment_seats"], [1, 2])
+        self.assertEqual(law["constituencies"], [
+            {"name": "I",  "num_const_seats": 2, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 3, "num_adj_seats": 2}
+        ])
 
     def test_generate_ind_const_ruleset(self):
         ind_const = self.rules.generate_ind_const_ruleset()
@@ -50,9 +53,10 @@ class TestElectionRules(TestCase):
         self.assertEqual(ind_const["adj_alloc_divider"], "nordic")
         self.assertEqual(ind_const["adjustment_threshold"], 4)
         self.assertEqual(ind_const["parties"], ["A", "B"])
-        self.assertEqual(ind_const["constituency_names"], ["I", "II"])
-        self.assertEqual(ind_const["constituency_seats"], [3, 5])
-        self.assertEqual(ind_const["constituency_adjustment_seats"], [0, 0])
+        self.assertEqual(ind_const["constituencies"], [
+            {"name": "I",  "num_const_seats": 3, "num_adj_seats": 0},
+            {"name": "II", "num_const_seats": 5, "num_adj_seats": 0}
+        ])
 
     def test_generate_one_const_ruleset(self):
         one_const = self.rules.generate_one_const_ruleset()
@@ -62,9 +66,9 @@ class TestElectionRules(TestCase):
         self.assertEqual(one_const["adj_alloc_divider"], "nordic")
         self.assertEqual(one_const["adjustment_threshold"], 4)
         self.assertEqual(one_const["parties"], ["A", "B"])
-        self.assertEqual(one_const["constituency_names"], ["All"])
-        self.assertEqual(one_const["constituency_seats"], [5])
-        self.assertEqual(one_const["constituency_adjustment_seats"], [3])
+        self.assertEqual(one_const["constituencies"], [
+            {"name": "All",  "num_const_seats": 5, "num_adj_seats": 3}
+        ])
 
     def test_generate_all_adj_ruleset(self):
         all_adj = self.rules.generate_all_adj_ruleset()
@@ -74,6 +78,7 @@ class TestElectionRules(TestCase):
         self.assertEqual(all_adj["adj_alloc_divider"], "nordic")
         self.assertEqual(all_adj["adjustment_threshold"], 4)
         self.assertEqual(all_adj["parties"], ["A", "B"])
-        self.assertEqual(all_adj["constituency_names"], ["I", "II"])
-        self.assertEqual(all_adj["constituency_seats"], [0, 0])
-        self.assertEqual(all_adj["constituency_adjustment_seats"], [3, 5])
+        self.assertEqual(all_adj["constituencies"], [
+            {"name": "I",  "num_const_seats": 0, "num_adj_seats": 3},
+            {"name": "II", "num_const_seats": 0, "num_adj_seats": 5}
+        ])

--- a/backend/tests/entropy.py
+++ b/backend/tests/entropy.py
@@ -12,9 +12,10 @@ class TestEntropy(unittest.TestCase):
         self.rules["show_entropy"] = True
         self.rules["parties"] = ["A", "B"]
         self.rules["adjustment_method"] = "alternating-scaling"
-        self.rules["constituency_names"] = ["I", "II"]
-        self.rules["constituency_seats"] = [2, 3]
-        self.rules["constituency_adjustment_seats"] = [1, 2]
+        self.rules["constituencies"] = [
+            {"name": "I",  "num_const_seats": 2, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 3, "num_adj_seats": 2}
+        ]
         self.votes = [[500, 400],[300, 200]]
         self.election = Election(self.rules, self.votes)
         self.election.run()

--- a/backend/tests/measures.py
+++ b/backend/tests/measures.py
@@ -17,9 +17,11 @@ class MeasureTest(TestCase):
     def test_all_adj(self):
         #Arrange
         self.e_rules["adjustment_method"] = "icelandic-law"
-        self.e_rules["constituency_names"]            = ["I", "II", "III"]
-        self.e_rules["constituency_seats"]            = [ 1,    1,     1 ]
-        self.e_rules["constituency_adjustment_seats"] = [ 0,    0,     0 ]
+        self.e_rules["constituencies"] = [
+            {"name": "I",   "num_const_seats": 1, "num_adj_seats": 0},
+            {"name": "II",  "num_const_seats": 1, "num_adj_seats": 0},
+            {"name": "III", "num_const_seats": 1, "num_adj_seats": 0},
+        ]
         self.e_rules["parties"] = ["A", "B"]
         self.votes =             [[500, 600],
                                   [200, 400],
@@ -55,9 +57,10 @@ class MeasureTest(TestCase):
     def test_adj_dev(self):
         #Arrange
         self.e_rules["adjustment_method"] = "icelandic-law"
-        self.e_rules["constituency_names"]            = ["I", "II"]
-        self.e_rules["constituency_seats"]            = [ 1,    1 ]
-        self.e_rules["constituency_adjustment_seats"] = [ 1,    1 ]
+        self.e_rules["constituencies"] = [
+            {"name": "I",  "num_const_seats": 1, "num_adj_seats": 1},
+            {"name": "II", "num_const_seats": 1, "num_adj_seats": 1},
+        ]
         self.e_rules["parties"] = ["A", "B"]
         self.votes =             [[1500, 0],
                                   [0, 5000]]

--- a/backend/tests/methods.py
+++ b/backend/tests/methods.py
@@ -49,6 +49,8 @@ class TestAdjustmentMethods(TestCase):
         parties, votes = util.load_votes(votes_file, self.rules["constituencies"])
         self.rules["parties"] = parties
         self.rules_6c["parties"] = parties
+        self.rules["adjustment_threshold"] = 5
+        self.rules_6c["adjustment_threshold"] = 5
         self.votes = votes
 
     def test_alternating_scaling_small(self):

--- a/backend/tests/simulation.py
+++ b/backend/tests/simulation.py
@@ -11,9 +11,11 @@ import util
 class SimulationTest(TestCase):
     def setUp(self):
         self.e_rules = voting.ElectionRules()
-        self.e_rules["constituency_names"] = ["I", "II", "III"]
-        self.e_rules["constituency_seats"] = [5, 6, 4]
-        self.e_rules["constituency_adjustment_seats"] = [1, 2, 1]
+        self.e_rules["constituencies"] = [
+            {"name": "I",   "num_const_seats": 5, "num_adj_seats": 1},
+            {"name": "II",  "num_const_seats": 6, "num_adj_seats": 2},
+            {"name": "III", "num_const_seats": 4, "num_adj_seats": 1},
+        ]
         self.e_rules["parties"] = ["A", "B"]
         self.votes = [[500, 300], [200, 400], [350, 450]]
         self.s_rules = simulate.SimulationRules()

--- a/backend/util.py
+++ b/backend/util.py
@@ -51,8 +51,8 @@ def load_constituencies(confile):
                             "must add to a nonzero number.")
         cons.append({
             "name": row[0],
-            "num_constituency_seats": int(row[1]),
-            "num_adjustment_seats": int(row[2])})
+            "num_const_seats": int(row[1]),
+            "num_adj_seats": int(row[2])})
     return cons
 
 def load_votes_from_stream(stream, filename):

--- a/backend/util.py
+++ b/backend/util.py
@@ -136,7 +136,7 @@ def parse_input(
     } for row in input[start_row:]]
 
     table_name = input[0][0] if name_included else ''
-    res["table_name"] = determine_table_name(table_name,filename)
+    res["name"] = determine_table_name(table_name,filename)
 
     return res
 

--- a/backend/util.py
+++ b/backend/util.py
@@ -72,7 +72,7 @@ def load_votes_from_stream(stream, filename):
     else:
         return None, None, None
 
-    name_incl = rd[0][0].lower() != u"kjördæmi"
+    name_incl = rd[0][0].lower() != u"kjördæmi" if rd[0][0] else False
     const_seats_incl = rd[0][1].lower() == "cons"
     expected = 2 if const_seats_incl else 1
     adj_seats_incl = rd[0][expected].lower() == "adj"

--- a/backend/util.py
+++ b/backend/util.py
@@ -157,7 +157,18 @@ def parse_input(
     else:
         res["constituency_adjustment_seats"] = [0]*num_constituencies
 
-    return res
+    constituencies = [{
+        "name": res["constituencies"][c],
+        "num_const_seats": res["constituency_seats"][c],
+        "num_adj_seats": res["constituency_adjustment_seats"][c],
+    } for c in range(num_constituencies)]
+
+    return {
+        "table_name": res["table_name"],
+        "parties": res["parties"],
+        "constituencies": constituencies,
+        "votes": res["votes"]
+    }
 
 def parsint(value):
     return int(value) if value else 0

--- a/backend/util.py
+++ b/backend/util.py
@@ -43,7 +43,7 @@ def load_constituencies(confile):
     cons = []
     for row in reader:
         try:
-            assert(int(row[1]) + int(row[2]) >= 0)
+            assert(int(row[1]) + int(row[2]) > 0)
         except Exception as e:
             print(row[1:3])
             raise Exception("Error loading constituency file: "

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -13,9 +13,10 @@ from dictionaries import ADJUSTMENT_METHODS
 
 class Election:
     """A single election."""
-    def __init__(self, rules, votes=None):
+    def __init__(self, rules, votes=None, name=''):
         self.num_constituencies = len(rules["constituencies"])
         self.rules = rules
+        self.name = name
         self.set_votes(votes)
 
     def entropy(self):

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -14,9 +14,7 @@ from dictionaries import ADJUSTMENT_METHODS
 class Election:
     """A single election."""
     def __init__(self, rules, votes=None):
-        self.num_constituencies = len(rules["constituency_adjustment_seats"])
-        assert(len(rules["constituency_seats"]) == self.num_constituencies)
-        assert(len(rules["constituency_names"]) == self.num_constituencies)
+        self.num_constituencies = len(rules["constituencies"])
         self.rules = rules
         self.set_votes(votes)
 
@@ -43,10 +41,10 @@ class Election:
         # Which seats does each party get in each constituency:
         self.order = []
         # Determine total seats (const + adjustment) in each constituency:
-        self.v_total_seats = [sum(x) for x in
-                              zip(self.rules["constituency_seats"],
-                                  self.rules["constituency_adjustment_seats"])
-                             ]
+        self.v_total_seats = [
+            const["num_const_seats"] + const["num_adj_seats"]
+            for const in self.rules["constituencies"]
+        ]
         # Determine total seats in play:
         self.total_seats = sum(self.v_total_seats)
 
@@ -62,13 +60,13 @@ class Election:
             print(" + Primary apportionment")
 
         gen = self.rules.get_generator("primary_divider")
-        const_seats = self.rules["constituency_seats"]
+        constituencies = self.rules["constituencies"]
         parties = self.rules["parties"]
 
         m_allocations = []
         self.last = []
-        for i in range(len(const_seats)):
-            num_seats = const_seats[i]
+        for i in range(len(constituencies)):
+            num_seats = constituencies[i]["num_const_seats"]
             if num_seats != 0:
                 alloc, div = apportion1d(self.m_votes[i], num_seats, [0]*len(parties), gen)
                 self.last.append(div[2])

--- a/backend/web.py
+++ b/backend/web.py
@@ -147,7 +147,8 @@ def get_election_excel():
 
     tmpfilename = tempfile.mktemp(prefix='election-')
     election.to_xlsx(tmpfilename)
-    attachment_filename=f"election {datetime.now().strftime('%Y.%m.%d %H.%M.%S')}.xlsx"
+    date = datetime.now().strftime('%Y.%m.%d %H.%M.%S')
+    attachment_filename=f"election {date}.xlsx"
     DOWNLOADS[did] = tmpfilename, attachment_filename
     return jsonify({"download_id": did})
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -95,10 +95,10 @@ def check_vote_table(vote_table):
     num_constituencies = len(vote_table["constituencies"])
 
     if not len(vote_table["votes"]) == num_constituencies:
-        raise ValueError("The data is malformed.")
+        raise ValueError("The vote_table does not match the constituency list.")
     for row in vote_table["votes"]:
         if not len(row) == num_parties:
-            raise ValueError("The data is malformed.")
+            raise ValueError("The vote_table does not match the party list.")
         for p in range(len(row)):
             if not row[p]: row[p] = 0
             if type(row[p]) != int: raise TypeError("Votes must be numbers.")
@@ -106,15 +106,17 @@ def check_vote_table(vote_table):
     for const in vote_table["constituencies"]:
         if "name" not in const or not const["name"]:
             raise KeyError(f"Missing data ('vote_table.constituencies[x].name')")
+            name = const["name"]
         for info in ["num_const_seats", "num_adj_seats"]:
             if info not in const:
-                raise KeyError(f"Missing data ('vote_table.constituencies[x].{info}')")
+                raise KeyError(f"Missing data ('{info}' for {name})")
             if not const[info]: const[info] = 0
             if type(const[info]) != int:
                 raise TypeError("Seat specifications must be numbers.")
         if const["num_const_seats"]+const["num_adj_seats"] <= 0:
             raise ValueError("Constituency seats and adjustment seats "
-                             "must add to a nonzero number.")
+                             "must add to a nonzero number. "
+                             f"This is not the case for {name}.")
 
     return vote_table
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -98,9 +98,15 @@ def handle_election():
     rules["parties"] = vote_table["parties"]
     rules["constituencies"] = vote_table["constituencies"]
     for const in rules["constituencies"]:
-        for info in ["name", "num_const_seats", "num_adj_seats"]:
+        if "name" not in const or not const["name"]:
+            return {"error": f"Missing data ('vote_table.constituencies[x].name')"}
+        for info in ["num_const_seats", "num_adj_seats"]:
             if info not in const:
                 return {"error": f"Missing data ('vote_table.constituencies[x].{info}')"}
+            if not const[info]:
+                const[info] = 0
+            if type(const[info]) != int:
+                return {"error": "Seat numbers must be numbers."}
         if const["num_const_seats"]+const["num_adj_seats"] <= 0:
             return {"error": "Constituency seats and adjustment seats "
                              "must add to a nonzero number."}

--- a/backend/web.py
+++ b/backend/web.py
@@ -383,7 +383,11 @@ def set_up_simulation():
         election_rules["parties"] = vote_table["parties"]
         election_rules["constituencies"] = vote_table["constituencies"]
         for const in election_rules["constituencies"]:
+            if "name" not in const or not const["name"]:
+                return False, f"Missing data ('vote_table.constituencies[x].name')"
             for info in ["num_const_seats", "num_adj_seats"]:
+                if info not in const:
+                    return False, f"Missing data ('vote_table.constituencies[x].{info}')"
                 if not const[info]: const[info] = 0
                 if type(const[info]) != int:
                     return False, "Seat specifications must be numbers."

--- a/backend/web.py
+++ b/backend/web.py
@@ -139,8 +139,7 @@ def get_election_results():
         print(result["error"])
         return jsonify(result)
 
-    elections = result
-    return jsonify([election.get_results_dict() for election in elections])
+    return jsonify([election.get_results_dict() for election in result])
 
 @app.route('/api/election/getxlsx/', methods=['POST'])
 def get_election_excel():

--- a/backend/web.py
+++ b/backend/web.py
@@ -469,23 +469,6 @@ def get_presets_dict():
     #    data = {'error': 'Could not load presets due to parse error.'}
 
     return data
-    # presetsdir = "../data/presets/"
-    # try:
-    #     files = [f for f in listdir(presetsdir) if isfile(join(presetsdir, f))
-    #              and f.endswith('.json')]
-    # except Exception as e:
-    #     print("Presets directory read failure: %s" % (e))
-    #     files = []
-    # pr = []
-    # for f in files:
-    #     try:
-    #         with open(presetsdir+f) as json_file:
-    #             data = json.load(json_file)
-    #     except  json.decoder.JSONDecodeError:
-    #         data = {'error': 'Problem parsing json, please fix "{}"'.format(
-    #             presetsdir+f)}
-    #     pr.append(data)
-    # return pr
 
 def run_script(rules):
     if type(rules) in ["str", "unicode"]:

--- a/backend/web.py
+++ b/backend/web.py
@@ -93,10 +93,17 @@ def handle_election():
 
     table_name = vote_table["name"]
     votes = vote_table["votes"]
+    num_parties = len(vote_table["parties"])
+    num_constituencies = len(vote_table["constituencies"])
+
+    if not len(votes) == num_constituencies:
+        raise ValueError("The data is malformed.")
     for row in votes:
+        if not len(row) == num_parties:
+            raise ValueError("The data is malformed.")
         for p in range(len(row)):
             if not row[p]: row[p] = 0
-            if type(row[p]) != int: raise ValueError("Votes must be numbers.")
+            if type(row[p]) != int: raise TypeError("Votes must be numbers.")
 
     elections = []
     for rs in data["rules"]:
@@ -115,7 +122,7 @@ def handle_election():
                     raise KeyError(f"Missing data ('vote_table.constituencies[x].{info}')")
                 if not const[info]: const[info] = 0
                 if type(const[info]) != int:
-                    raise ValueError("Seat specifications must be numbers.")
+                    raise TypeError("Seat specifications must be numbers.")
             if const["num_const_seats"]+const["num_adj_seats"] <= 0:
                 raise ValueError("Constituency seats and adjustment seats "
                                  "must add to a nonzero number.")
@@ -130,9 +137,8 @@ def handle_election():
 def get_election_results():
     try:
         result = handle_election()
-    except (KeyError, ValueError, AssertionError, ZeroDivisionError) as e:
-        message = "The data is malformed."  if isinstance(e, AssertionError)\
-            else "Need to have more votes." if isinstance(e, ZeroDivisionError)\
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as e:
+        message = "Need to have more votes." if isinstance(e, ZeroDivisionError)\
             else e.args[0]
         print(message)
         return jsonify({"error": message})
@@ -146,9 +152,8 @@ def get_election_excel():
 
     try:
         result = handle_election()
-    except (KeyError, ValueError, AssertionError, ZeroDivisionError) as e:
-        message = "The data is malformed."  if isinstance(e, AssertionError)\
-            else "Need to have more votes." if isinstance(e, ZeroDivisionError)\
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as e:
+        message = "Need to have more votes." if isinstance(e, ZeroDivisionError)\
             else e.args[0]
         return jsonify({"error": message})
 
@@ -167,9 +172,8 @@ def save_votes():
 
     try:
         result = prepare_to_save_vote_table()
-    except (KeyError, ValueError, AssertionError) as e:
-        message = "The data is malformed." if isinstance(e, AssertionError)\
-            else e.args[0]
+    except (KeyError, ValueError) as e:
+        message = e.args[0]
         print(message)
         return jsonify({"error": message})
 
@@ -192,8 +196,9 @@ def prepare_to_save_vote_table():
 
     num_constituencies = len(vote_table["constituencies"])
     num_parties = len(vote_table["parties"])
-    assert(num_constituencies == len(vote_table["votes"]))
-    assert(all([num_parties == len(row) for row in vote_table["votes"]]))
+    if not (len(vote_table["votes"] == num_constituencies)
+            and all([len(row) == num_parties for row in vote_table["votes"]])):
+        raise ValueError("The data is malformed.")
     file_matrix = [
         [vote_table["name"], "cons", "adj"] + vote_table["parties"],
     ] + [
@@ -278,9 +283,8 @@ def start_simulation():
 
     try:
         simulation = set_up_simulation()
-    except (KeyError, ValueError, AssertionError, ZeroDivisionError) as e:
-        message = "The data is malformed."  if isinstance(e, AssertionError)\
-            else "Need to have more votes." if isinstance(e, ZeroDivisionError)\
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as e:
+        message = "Need to have more votes." if isinstance(e, ZeroDivisionError)\
             else e.args[0]
         print(message)
         return jsonify({"started": False, "error": message})
@@ -378,10 +382,17 @@ def set_up_simulation():
 
     table_name = vote_table["name"]
     votes = vote_table["votes"]
+    num_parties = len(vote_table["parties"])
+    num_constituencies = len(vote_table["constituencies"])
+
+    if not len(votes) == num_constituencies:
+        raise ValueError("The data is malformed.")
     for row in votes:
+        if not len(row) == num_parties:
+            raise ValueError("The data is malformed.")
         for p in range(len(row)):
             if not row[p]: row[p] = 0
-            if type(row[p]) != int: raise ValueError("Votes must be numbers.")
+            if type(row[p]) != int: raise TypeError("Votes must be numbers.")
 
     rulesets = []
     for rs in data["election_rules"]:
@@ -400,7 +411,7 @@ def set_up_simulation():
                     raise KeyError(f"Missing data ('vote_table.constituencies[x].{info}')")
                 if not const[info]: const[info] = 0
                 if type(const[info]) != int:
-                    raise ValueError("Seat specifications must be numbers.")
+                    raise TypeError("Seat specifications must be numbers.")
             if const["num_const_seats"]+const["num_adj_seats"] <= 0:
                 raise ValueError("Constituency seats and adjustment seats "
                                  "must add to a nonzero number.")

--- a/backend/web.py
+++ b/backend/web.py
@@ -111,6 +111,7 @@ def handle_election():
             return {"error": "Constituency seats and adjustment seats "
                              "must add to a nonzero number."}
 
+    table_name = vote_table["name"]
     votes = vote_table["votes"]
     for c in range(len(votes)):
         for p in range(len(votes[c])):
@@ -120,7 +121,7 @@ def handle_election():
                 return {"error": "Votes must be numbers."}
 
     try:
-        election = voting.Election(rules, votes)
+        election = voting.Election(rules, votes, table_name)
         election.run()
     except ZeroDivisionError:
         return {"error": "Need to have more votes."}

--- a/backend/web.py
+++ b/backend/web.py
@@ -346,7 +346,6 @@ def get_xlsx():
 
 def set_up_simulation():
     data = request.get_json(force=True)
-    rulesets = []
 
     for section in ["vote_table", "election_rules", "simulation_rules"]:
         if section not in data or not data[section]:
@@ -363,6 +362,15 @@ def set_up_simulation():
         if info not in vote_table or not vote_table[info]:
             return False, f"Missing data ('{info}')"
 
+    table_name = vote_table["name"]
+    votes = vote_table["votes"]
+
+    for row in votes:
+        for p in range(len(row)):
+            if not row[p]: row[p] = 0
+            if type(row[p]) != int: return False, "Votes must be numbers."
+
+    rulesets = []
     for rs in data["election_rules"]:
         election_rules = ElectionRules()
 
@@ -384,14 +392,6 @@ def set_up_simulation():
                               "must add to a nonzero number."
 
         rulesets.append(election_rules)
-
-    table_name = vote_table["name"]
-    votes = vote_table["votes"]
-
-    for row in votes:
-        for p in range(len(row)):
-            if not row[p]: row[p] = 0
-            if type(row[p]) != int: return False, "Votes must be numbers."
 
     stability_parameter = 100
     if "stbl_param" in data:

--- a/backend/web.py
+++ b/backend/web.py
@@ -374,10 +374,7 @@ def set_up_simulation():
     for rs in data["election_rules"]:
         election_rules = ElectionRules()
 
-        print(data["election_rules"])
-        print(rs)
         for k, v in rs.items():
-            print("Setting election_rules[%s] = %s" % (k, v))
             election_rules[k] = v
 
         election_rules["parties"] = vote_table["parties"]

--- a/backend/web.py
+++ b/backend/web.py
@@ -106,6 +106,10 @@ def handle_election():
         "num_const_seats": vote_table["constituency_seats"][c],
         "num_adj_seats": vote_table["constituency_adjustment_seats"][c],
     } for c in range(num_constituencies)]
+    for const in rules["constituencies"]:
+        if const["num_const_seats"]+const["num_adj_seats"] <= 0:
+            return {"error": "Constituency seats and adjustment seats "
+                             "must add to a nonzero number."}
 
     votes = vote_table["votes"]
     for c in range(len(votes)):
@@ -379,6 +383,10 @@ def set_up_simulation():
                     election_rules["constituencies"][c][info] = 0
                 if type(election_rules["constituencies"][c][info]) != int:
                     return False, "Seat specifications must be numbers."
+        for const in election_rules["constituencies"]:
+            if const["num_const_seats"]+const["num_adj_seats"] <= 0:
+                return False, "Constituency seats and adjustment seats "
+                              "must add to a nonzero number."
 
         rulesets.append(election_rules)
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -186,7 +186,7 @@ def save_votes():
 
     try:
         result = prepare_to_save_vote_table()
-    except (KeyError, ValueError) as e:
+    except (KeyError, TypeError, ValueError) as e:
         message = e.args[0]
         print(message)
         return jsonify({"error": message})

--- a/backend/web.py
+++ b/backend/web.py
@@ -131,6 +131,7 @@ def handle_election():
 def get_election_results():
     result = handle_election()
     if type(result)==dict and "error" in result:
+        print(result["error"])
         return jsonify(result)
 
     election = result
@@ -143,6 +144,7 @@ def get_election_excel():
 
     result = handle_election()
     if type(result)==dict and "error" in result:
+        print(result["error"])
         return jsonify(result)
 
     tmpfilename = tempfile.mktemp(prefix='election-')

--- a/backend/web.py
+++ b/backend/web.py
@@ -129,10 +129,11 @@ def handle_election():
 
 @app.route('/api/election/', methods=["POST"])
 def get_election_results():
-    election = handle_election()
-    if type(election)==dict and "error" in election:
-        return jsonify(election)
+    result = handle_election()
+    if type(result)==dict and "error" in result:
+        return jsonify(result)
 
+    election = result
     return jsonify(election.get_results_dict())
 
 @app.route('/api/election/getxlsx/', methods=['POST'])
@@ -140,9 +141,9 @@ def get_election_excel():
     global DOWNLOADS
     did = get_new_download_id()
 
-    election = handle_election()
-    if type(election)==dict and "error" in election:
-        return jsonify(election)
+    result = handle_election()
+    if type(result)==dict and "error" in result:
+        return jsonify(result)
 
     tmpfilename = tempfile.mktemp(prefix='election-')
     election.to_xlsx(tmpfilename)

--- a/backend/web.py
+++ b/backend/web.py
@@ -103,8 +103,7 @@ def handle_election():
         for info in ["num_const_seats", "num_adj_seats"]:
             if info not in const:
                 return {"error": f"Missing data ('vote_table.constituencies[x].{info}')"}
-            if not const[info]:
-                const[info] = 0
+            if not const[info]: const[info] = 0
             if type(const[info]) != int:
                 return {"error": "Seat numbers must be numbers."}
         if const["num_const_seats"]+const["num_adj_seats"] <= 0:
@@ -113,12 +112,10 @@ def handle_election():
 
     table_name = vote_table["name"]
     votes = vote_table["votes"]
-    for c in range(len(votes)):
-        for p in range(len(votes[c])):
-            if not votes[c][p]:
-                votes[c][p] = 0
-            if type(votes[c][p]) != int:
-                return {"error": "Votes must be numbers."}
+    for row in votes:
+        for p in range(len(row)):
+            if not row[p]: row[p] = 0
+            if type(row[p]) != int: return {"error": "Votes must be numbers."}
 
     try:
         election = voting.Election(rules, votes, table_name)
@@ -368,13 +365,11 @@ def set_up_simulation():
 
         election_rules["parties"] = vote_table["parties"]
         election_rules["constituencies"] = vote_table["constituencies"]
-        for c in range(len(election_rules["constituencies"])):
-            for info in ["num_const_seats", "num_adj_seats"]:
-                if not election_rules["constituencies"][c][info]:
-                    election_rules["constituencies"][c][info] = 0
-                if type(election_rules["constituencies"][c][info]) != int:
-                    return False, "Seat specifications must be numbers."
         for const in election_rules["constituencies"]:
+            for info in ["num_const_seats", "num_adj_seats"]:
+                if not const[info]: const[info] = 0
+                if type(const[info]) != int:
+                    return False, "Seat specifications must be numbers."
             if const["num_const_seats"]+const["num_adj_seats"] <= 0:
                 return False, "Constituency seats and adjustment seats " \
                               "must add to a nonzero number."
@@ -384,12 +379,10 @@ def set_up_simulation():
     table_name = vote_table["name"]
     votes = vote_table["votes"]
 
-    for c in range(len(votes)):
-        for p in range(len(votes[c])):
-            if not votes[c][p]:
-                votes[c][p] = 0
-            if type(votes[c][p]) != int:
-                return False, "Votes must be numbers."
+    for row in votes:
+        for p in range(len(row)):
+            if not row[p]: row[p] = 0
+            if type(row[p]) != int: return False, "Votes must be numbers."
 
     stability_parameter = 100
     if "stbl_param" in data:

--- a/backend/web.py
+++ b/backend/web.py
@@ -457,9 +457,6 @@ def get_capabilities_dict():
     }
 
 def get_presets_dict():
-    from os import listdir
-    from os.path import isfile, join
-
     try:
         with open('../data/presets.json', encoding='utf-8') as js:
             data = json.load(js)

--- a/data/presets/iceland2013.json
+++ b/data/presets/iceland2013.json
@@ -6,15 +6,13 @@
     "adjustment_divider": "dhondt",
     "adjustment_threshold": 0.05,
     "adjustment_method": "icelandic-law",
-    "constituency_seats": [7, 9, 9, 11, 9, 9],
-    "constituency_adjustment_seats": [1, 1, 1, 2, 2, 2],
-    "constituency_names": [
-      "Norðvestur",
-      "Norðaustur",
-      "Suður",
-      "Suðvestur",
-      "Reykjavík suður",
-      "Reykjavík norður"
+    "constituencies": [
+      {"name": "Norðvestur",       "num_const_seats":  7, "num_adj_seats": 1},
+      {"name": "Norðaustur",       "num_const_seats":  9, "num_adj_seats": 1},
+      {"name": "Suður",            "num_const_seats":  9, "num_adj_seats": 1},
+      {"name": "Suðvestur",        "num_const_seats": 11, "num_adj_seats": 2},
+      {"name": "Reykjavík suður",  "num_const_seats":  9, "num_adj_seats": 2},
+      {"name": "Reykjavík norður", "num_const_seats":  9, "num_adj_seats": 2}
     ],
     "parties": ["A","B","D","G","H","I","J","K","L","M","R","S","T","V","Þ"],
     "votes": [

--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -6,7 +6,7 @@
       <b-collapse is-nav id="nav_collapse">
         <b-navbar-nav>
           <b-nav-item href="#/">Instructions</b-nav-item>
-          <b-nav-item href="#/main">Main</b-nav-item>
+          <b-nav-item href="#/calc">Calculator</b-nav-item>
         </b-navbar-nav>
       </b-collapse>
     </b-navbar>

--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -6,8 +6,7 @@
       <b-collapse is-nav id="nav_collapse">
         <b-navbar-nav>
           <b-nav-item href="#/">Instructions</b-nav-item>
-          <b-nav-item href="#/election">Single Election</b-nav-item>
-          <b-nav-item href="#/simulate">Simulate</b-nav-item>
+          <b-nav-item href="#/main">Main</b-nav-item>
         </b-navbar-nav>
       </b-collapse>
     </b-navbar>

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -3,13 +3,28 @@
   <h1>Election</h1>
 
   <h2>Settings</h2>
-  <b-container>
-    <ElectionSettings
-      server="server"
-      :rules="rules"
-      @update-rules="updateRules">
-    </ElectionSettings>
-  </b-container>
+  <b-card no-body>
+    <b-tabs card>
+      <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
+        <div slot="title">
+          <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
+          {{rulesidx}}-{{rules.name}}
+        </div>
+        <ElectionSettings
+          :rulesidx="rulesidx"
+          :rules="rules"
+          @update-rules="updateElectionRules">
+        </ElectionSettings>
+      </b-tab>
+      <template slot="tabs">
+        <b-button size="sm" @click="addElectionRules"><b>+</b></b-button>
+      </template>
+      <div slot="empty">
+        There are no electoral systems specified.
+        Use the + button to create a new electoral system.
+      </div>
+    </b-tabs>
+  </b-card>
 
   <h2>Results</h2>
   <b-button size="lg" @click="get_xlsx">Download XLSX file</b-button>
@@ -52,16 +67,20 @@ export default {
   data: function() {
     return {
       doneCreating: false,
-      rules: {},
+      election_rules: [{}],
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
   },
   watch: {
     'vote_table': {
       handler: function (val, oldVal) {
-        if (this.doneCreating) {
-          this.recalculate();
-        }
+        this.recalculate();
+      },
+      deep: true
+    },
+    'election_rules': {
+      handler: function (val, oldVal) {
+        this.recalculate();
       },
       deep: true
     },
@@ -70,18 +89,24 @@ export default {
     this.doneCreating = true;
   },
   methods: {
-    updateRules: function(rules, recalc) {
-      this.rules = rules;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
+    addElectionRules: function() {
+      this.election_rules.push({})
+    },
+    deleteElectionRules: function(idx) {
+      this.election_rules.splice(idx, 1);
+    },
+    updateElectionRules: function(rules, idx) {
+      this.$set(this.election_rules, idx, rules);
     },
     recalculate: function() {
-      this.server.waitingForData = true;
-      this.$http.post('/api/election/',
+      if (this.doneCreating
+          && this.election_rules.length > 0
+          && this.election_rules[0].name) {
+        this.server.waitingForData = true;
+        this.$http.post('/api/election/',
         {
           vote_table: this.vote_table,
-          rules: this.rules,
+          rules: this.election_rules[0],
         }).then(response => {
           if (response.body.error) {
             this.server.errormsg = response.body.error;
@@ -98,12 +123,13 @@ export default {
           this.server.error = true;
           this.server.waitingForData = false;
         });
+      }
     },
 
     get_xlsx: function() {
       this.$http.post('/api/election/getxlsx/', {
         vote_table: this.vote_table,
-        rules: this.rules,
+        rules: this.election_rules[0],
       }).then(response => {
         let link = document.createElement('a')
         link.href = '/api/downloads/get?id=' + response.data.download_id

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -2,30 +2,6 @@
 <div>
   <h1>Election</h1>
 
-  <h2>Settings</h2>
-  <b-card no-body>
-    <b-tabs v-model="activeTabIndex" card>
-      <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
-        <div slot="title">
-          <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
-          {{rulesidx}}-{{rules.name}}
-        </div>
-        <ElectionSettings
-          :rulesidx="rulesidx"
-          :rules="rules"
-          @update-rules="updateElectionRules">
-        </ElectionSettings>
-      </b-tab>
-      <template slot="tabs">
-        <b-button size="sm" @click="addElectionRules"><b>+</b></b-button>
-      </template>
-      <div slot="empty">
-        There are no electoral systems specified.
-        Use the + button to create a new electoral system.
-      </div>
-    </b-tabs>
-  </b-card>
-
   <h2>Results</h2>
   <b-button size="lg" @click="get_xlsx">Download XLSX file</b-button>
   <b-container>
@@ -47,27 +23,23 @@
 </template>
 
 <script>
-import VoteMatrix from './components/VoteMatrix.vue'
 import ResultMatrix from './components/ResultMatrix.vue'
 import ResultChart from './components/ResultChart.vue'
-import ElectionSettings from './components/ElectionSettings.vue'
 
 export default {
   props: {
     "vote_table": { default: {} },
     "election_rules": { default: [{}] },
+    "activeTabIndex": { default: 0 },
     "server": { default: {} },
   },
   components: {
-    VoteMatrix,
     ResultMatrix,
-    ElectionSettings,
     ResultChart
   },
 
   data: function() {
     return {
-      activeTabIndex: 0,
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
   },
@@ -86,15 +58,6 @@ export default {
     },
   },
   methods: {
-    addElectionRules: function() {
-      this.election_rules.push({})
-    },
-    deleteElectionRules: function(idx) {
-      this.election_rules.splice(idx, 1);
-    },
-    updateElectionRules: function(rules, idx) {
-      this.$set(this.election_rules, idx, rules);
-    },
     recalculate: function() {
       if (this.election_rules.length > 0
           && this.election_rules[this.activeTabIndex].name) {

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -66,10 +66,10 @@ export default {
       deep: true
     },
   },
+  created: function() {
+    this.doneCreating = true;
+  },
   methods: {
-    created: function() {
-      this.doneCreating = true;
-    },
     updateRules: function(rules, recalc) {
       this.rules = rules;
       if (recalc === true || recalc === undefined) {

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -48,6 +48,7 @@ export default {
 
   data: function() {
     return {
+      doneCreating: false,
       rules: {
         adjustment_divider: "",
         primary_divider: "",
@@ -60,12 +61,17 @@ export default {
   watch: {
     'vote_table': {
       handler: function (val, oldVal) {
-        this.recalculate();
+        if (this.doneCreating) {
+          this.recalculate();
+        }
       },
       deep: true
     },
   },
   methods: {
+    created: function() {
+      this.doneCreating = true;
+    },
     updateRules: function(rules, recalc) {
       this.rules = rules;
       if (recalc === true || recalc === undefined) {

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -60,6 +60,7 @@ export default {
   methods: {
     recalculate: function() {
       if (this.election_rules.length > 0
+          && this.election_rules.length > this.activeTabIndex
           && this.election_rules[this.activeTabIndex].name) {
         this.server.waitingForData = true;
         this.$http.post('/api/election/',

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -7,10 +7,7 @@
 
   <h2>Votes</h2>
   <VoteMatrix
-    @update-table-name="updateTableName"
-    @update-votes="updateVotes"
-    @update-parties="updateParties"
-    @update-constituencies="updateConstituencies"
+    @update-vote-table="updateVoteTable"
     @recalculate="recalculate"
     @server-error="serverError">
   </VoteMatrix>
@@ -61,16 +58,18 @@ export default {
         waitingForData: false,
         error: false,
       },
-      parties: [],
-      constituencies: [],
+      vote_table: {
+        name: "",
+        votes: [],
+        parties: [],
+        constituencies: [],
+      },
       rules: {
         adjustment_divider: "",
         primary_divider: "",
         adjustment_threshold: 0.0,
         adjustment_method: "",
       },
-      table_name: "",
-      votes: [],
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
   },
@@ -81,23 +80,8 @@ export default {
         this.recalculate();
       }
     },
-    updateTableName: function(name) {
-      this.table_name = name;
-    },
-    updateVotes: function(votes, recalc) {
-      this.votes = votes;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
-    },
-    updateConstituencies: function(cons, recalc) {
-      this.constituencies = cons;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
-    },
-    updateParties: function(parties, recalc) {
-      this.parties = parties;
+    updateVoteTable: function(table, recalc) {
+      this.vote_table = table;
       if (recalc === true || recalc === undefined) {
         this.recalculate();
       }
@@ -109,12 +93,7 @@ export default {
       this.server.waitingForData = true;
       this.$http.post('/api/election/',
         {
-          vote_table: {
-            name: this.table_name,
-            parties: this.parties,
-            constituencies: this.constituencies,
-            votes: this.votes,
-          },
+          vote_table: this.vote_table,
           rules: this.rules,
         }).then(response => {
           if (response.body.error) {
@@ -136,12 +115,7 @@ export default {
 
     get_xlsx: function() {
       this.$http.post('/api/election/getxlsx/', {
-        vote_table: {
-          name: this.table_name,
-          parties: this.parties,
-          constituencies: this.constituencies,
-          votes: this.votes,
-        },
+        vote_table: this.vote_table,
         rules: this.rules,
       }).then(response => {
         let link = document.createElement('a')

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -1,16 +1,6 @@
 <template>
 <div>
   <h1>Election</h1>
-  <b-alert :show="server.waitingForData">Loading...</b-alert>
-  <b-alert :show="server.error" dismissible @dismissed="server.error=false" variant="danger">Server error. Try again in a few seconds...</b-alert>
-  <b-alert :show="server.errormsg != ''" dismissible @dismissed="server.errormsg=''" variant="danger">Server error. {{server.errormsg}}</b-alert>
-
-  <h2>Votes</h2>
-  <VoteMatrix
-    @update-vote-table="updateVoteTable"
-    @recalculate="recalculate"
-    @server-error="serverError">
-  </VoteMatrix>
 
   <h2>Settings</h2>
   <b-container>
@@ -45,6 +35,10 @@ import ResultChart from './components/ResultChart.vue'
 import ElectionSettings from './components/ElectionSettings.vue'
 
 export default {
+  props: {
+    "vote_table": { default: {} },
+    "server": { default: {} },
+  },
   components: {
     VoteMatrix,
     ResultMatrix,
@@ -54,16 +48,6 @@ export default {
 
   data: function() {
     return {
-      server: {
-        waitingForData: false,
-        error: false,
-      },
-      vote_table: {
-        name: "",
-        votes: [],
-        parties: [],
-        constituencies: [],
-      },
       rules: {
         adjustment_divider: "",
         primary_divider: "",
@@ -73,21 +57,20 @@ export default {
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
   },
+  watch: {
+    'vote_table': {
+      handler: function (val, oldVal) {
+        this.recalculate();
+      },
+      deep: true
+    },
+  },
   methods: {
     updateRules: function(rules, recalc) {
       this.rules = rules;
       if (recalc === true || recalc === undefined) {
         this.recalculate();
       }
-    },
-    updateVoteTable: function(table, recalc) {
-      this.vote_table = table;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
-    },
-    serverError: function(error) {
-      this.server.errormsg = error;
     },
     recalculate: function() {
       this.server.waitingForData = true;

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -52,12 +52,7 @@ export default {
   data: function() {
     return {
       doneCreating: false,
-      rules: {
-        adjustment_divider: "",
-        primary_divider: "",
-        adjustment_threshold: 0.0,
-        adjustment_method: "",
-      },
+      rules: {},
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
   },

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -67,7 +67,6 @@ export default {
 
   data: function() {
     return {
-      doneCreating: false,
       activeTabIndex: 0,
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
@@ -86,9 +85,6 @@ export default {
       deep: true
     },
   },
-  created: function() {
-    this.doneCreating = true;
-  },
   methods: {
     addElectionRules: function() {
       this.election_rules.push({})
@@ -100,8 +96,7 @@ export default {
       this.$set(this.election_rules, idx, rules);
     },
     recalculate: function() {
-      if (this.doneCreating
-          && this.election_rules.length > 0
+      if (this.election_rules.length > 0
           && this.election_rules[this.activeTabIndex].name) {
         this.server.waitingForData = true;
         this.$http.post('/api/election/',

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -4,7 +4,10 @@
 
   <h2>Settings</h2>
   <b-container>
-    <ElectionSettings server="server" @update-rules="updateRules">
+    <ElectionSettings
+      server="server"
+      :rules="rules"
+      @update-rules="updateRules">
     </ElectionSettings>
   </b-container>
 

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -7,14 +7,16 @@
   <b-container>
     <b-row>
       <ResultMatrix
-        :constituencies="results.constituencies"
-        :parties="results.parties"
-        :values="results.seat_allocations"
+        :constituencies="vote_table.constituencies"
+        :parties="vote_table.parties"
+        :values="results[activeTabIndex].seat_allocations"
         :stddev="false">
       </ResultMatrix>
     </b-row>
     <b-row>
-      <ResultChart :parties="results.parties" :seats="results.seat_allocations">
+      <ResultChart
+        :parties="vote_table.parties"
+        :seats="results[activeTabIndex].seat_allocations">
       </ResultChart>
     </b-row>
   </b-container>
@@ -40,7 +42,7 @@ export default {
 
   data: function() {
     return {
-      results: { seat_allocations: [], parties: [], constituencies: []},
+      results: [],
     }
   },
   watch: {
@@ -65,7 +67,7 @@ export default {
         this.$http.post('/api/election/',
         {
           vote_table: this.vote_table,
-          rules: this.election_rules[this.activeTabIndex],
+          rules: this.election_rules,
         }).then(response => {
           if (response.body.error) {
             this.server.errormsg = response.body.error;
@@ -73,9 +75,7 @@ export default {
           } else {
             this.server.errormsg = '';
             this.server.error = false;
-            this.results["constituencies"] = response.body.rules.constituencies;
-            this.results["parties"] = response.body.rules.parties;
-            this.results["seat_allocations"] = response.body.seat_allocations;
+            this.results = response.body;
             this.server.waitingForData = false;
           }
         }, response => {
@@ -88,7 +88,7 @@ export default {
     get_xlsx: function() {
       this.$http.post('/api/election/getxlsx/', {
         vote_table: this.vote_table,
-        rules: this.election_rules[this.activeTabIndex],
+        rules: [this.election_rules[this.activeTabIndex]],
       }).then(response => {
         let link = document.createElement('a')
         link.href = '/api/downloads/get?id=' + response.data.download_id

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -4,7 +4,7 @@
 
   <h2>Settings</h2>
   <b-card no-body>
-    <b-tabs card>
+    <b-tabs v-model="activeTabIndex" card>
       <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
         <div slot="title">
           <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
@@ -68,6 +68,7 @@ export default {
     return {
       doneCreating: false,
       election_rules: [{}],
+      activeTabIndex: 0,
       results: { seat_allocations: [], parties: [], constituencies: []},
     }
   },
@@ -101,12 +102,12 @@ export default {
     recalculate: function() {
       if (this.doneCreating
           && this.election_rules.length > 0
-          && this.election_rules[0].name) {
+          && this.election_rules[this.activeTabIndex].name) {
         this.server.waitingForData = true;
         this.$http.post('/api/election/',
         {
           vote_table: this.vote_table,
-          rules: this.election_rules[0],
+          rules: this.election_rules[this.activeTabIndex],
         }).then(response => {
           if (response.body.error) {
             this.server.errormsg = response.body.error;
@@ -129,7 +130,7 @@ export default {
     get_xlsx: function() {
       this.$http.post('/api/election/getxlsx/', {
         vote_table: this.vote_table,
-        rules: this.election_rules[0],
+        rules: this.election_rules[this.activeTabIndex],
       }).then(response => {
         let link = document.createElement('a')
         link.href = '/api/downloads/get?id=' + response.data.download_id

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -1,7 +1,5 @@
 <template>
 <div>
-  <h1>Election</h1>
-
   <h2>Results</h2>
   <b-button size="lg" @click="get_xlsx">Download XLSX file</b-button>
   <b-container>

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -55,6 +55,7 @@ import ElectionSettings from './components/ElectionSettings.vue'
 export default {
   props: {
     "vote_table": { default: {} },
+    "election_rules": { default: [{}] },
     "server": { default: {} },
   },
   components: {
@@ -67,7 +68,6 @@ export default {
   data: function() {
     return {
       doneCreating: false,
-      election_rules: [{}],
       activeTabIndex: 0,
       results: { seat_allocations: [], parties: [], constituencies: []},
     }

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -9,8 +9,6 @@
   <VoteMatrix
     @update-table-name="updateTableName"
     @update-votes="updateVotes"
-    @update-adjustment-seats="updateAdjustmentSeats"
-    @update-constituency-seats="updateConstituencySeats"
     @update-parties="updateParties"
     @update-constituencies="updateConstituencies"
     @recalculate="recalculate"
@@ -63,10 +61,8 @@ export default {
         waitingForData: false,
         error: false,
       },
-      constituency_names: [],
       parties: [],
-      constituency_seats: [],
-      constituency_adjustment_seats: [],
+      constituencies: [],
       rules: {
         adjustment_divider: "",
         primary_divider: "",
@@ -94,20 +90,8 @@ export default {
         this.recalculate();
       }
     },
-    updateConstituencySeats: function(seats, recalc) {
-      this.constituency_seats = seats;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
-    },
-    updateAdjustmentSeats: function(seats, recalc) {
-      this.constituency_adjustment_seats = seats;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
-    },
     updateConstituencies: function(cons, recalc) {
-      this.constituency_names = cons;
+      this.constituencies = cons;
       if (recalc === true || recalc === undefined) {
         this.recalculate();
       }
@@ -128,9 +112,7 @@ export default {
           vote_table: {
             name: this.table_name,
             parties: this.parties,
-            constituency_names: this.constituency_names,
-            constituency_seats: this.constituency_seats,
-            constituency_adjustment_seats: this.constituency_adjustment_seats,
+            constituencies: this.constituencies,
             votes: this.votes,
           },
           rules: this.rules,
@@ -141,7 +123,7 @@ export default {
           } else {
             this.server.errormsg = '';
             this.server.error = false;
-            this.results["constituencies"] = response.body.rules.constituency_names;
+            this.results["constituencies"] = response.body.rules.constituencies;
             this.results["parties"] = response.body.rules.parties;
             this.results["seat_allocations"] = response.body.seat_allocations;
             this.server.waitingForData = false;
@@ -157,9 +139,7 @@ export default {
         vote_table: {
           name: this.table_name,
           parties: this.parties,
-          constituency_names: this.constituency_names,
-          constituency_seats: this.constituency_seats,
-          constituency_adjustment_seats: this.constituency_adjustment_seats,
+          constituencies: this.constituencies,
           votes: this.votes,
         },
         rules: this.rules,

--- a/vue-frontend/src/Election.vue
+++ b/vue-frontend/src/Election.vue
@@ -2,7 +2,7 @@
 <div>
   <h2>Results</h2>
   <b-button size="lg" @click="get_xlsx">Download XLSX file</b-button>
-  <b-container>
+  <b-container v-if="results[activeTabIndex] !== undefined">
     <b-row>
       <ResultMatrix
         :constituencies="vote_table.constituencies"

--- a/vue-frontend/src/Intro.vue
+++ b/vue-frontend/src/Intro.vue
@@ -3,12 +3,24 @@
   <h1>Voting system simulator</h1>
 
   <p>
-  Hello! This is a voting system simulator. Above, you can choose between two modes: <b><a href="#/election">Single Election</a></b> and <b><a href="#/simulate">Simulate</a></b>.
+    Hello! This is a voting system simulator.
+    Above, you can go to <b><a href="#/calc">Calculator</a></b>.
+    For instructions on how to use it, read below.
   </p>
 
   <h2>About</h2>
-  <p>The aim of this software is to help people understand how certain types of voting systems work under various conditions. It provides tools to calculate election results for certain systems and review various metrics for these systems under simulation.</p>
-  <p>This software is free to use for experimental purposes, and is free/open source software, available from <a href="https://github.com/smari/voting/">Github</a>. If you are using it for commercial or political reasons, please contact us to discuss supporting our project financially.
+  <p>
+    The aim of this software is to help people understand
+    how certain types of electoral systems work under various conditions.
+    It provides tools to calculate election results for certain systems
+    and review various metrics for these systems under simulation.
+  </p>
+  <p>
+    This software is free to use for experimental purposes,
+    and is free/open source software,
+    available from <a href="https://github.com/smari/voting/">Github</a>.
+    If you are using it for commercial or political reasons,
+    please contact us to discuss supporting our project financially.
   <p>
     The voting system simulator is made by:
   </p>
@@ -21,47 +33,117 @@
     <li>Bjartur Thorlacius</li>
   </ul>
 
-  <h2>Single Election</h2>
+  <h2>How to use the calculator</h2>
 
   <p>
-    <b><a href="#/election">Single Election</a></b> allows you to calculate the results of a single election. You need to provide <b>election rules</b> along with information about the <b>constituencies</b> in the country, the <b>parties</b> running in the election, and the <b>votes</b> each party got in each constituency.
+    The calculator has two modes: Single election and Simulation.
+    But both modes share some common settings.
+    You need to specify <b>electoral system settings</b>
+    along with information about the <b>constituencies</b> in the country,
+    the <b>parties</b> running in the election,
+    and the <b>votes</b> each party got in each constituency.
   </p>
   <p>
-    As you update these values, the result will be automatically calculated and the results displayed below.
+    When specifying an <i>electoral system</i>,
+    you have a lot of different options to choose from ─
+    for a deeper understanding of these,
+    you should read our guides on
+    <b><a title="Coming soon." data-href="#/dividers">
+      divider rules
+    </a></b>
+    and
+    <b><a title="Coming soon." data-href="#/adjustmentmethods">
+      adjustment methods
+    </a></b>
+    once we finish adding those.
   </p>
   <p>
-    When choosing the <i>election rules</i>, you have a lot of different options to choose from ─ for a deeper understanding of these, you should read our guides on <b><a href="#/dividers">divider rules</a></b> and <b><a href="#/adjustmentmethods">adjustment methods</a></b>.
+    You can manually edit the vote table,
+    adding or removing rows for constituencies and columns for parties,
+    naming the constituencies and parties
+    (and giving the table itself a name while you're at it,
+    to help you distinguish results of one table from the next),
+    specifying how many constituency seats or adjustment seats
+    should be allocated to each constituency
+    and last but not least,
+    supplying the vote counts to base the calculations on.
+    You can save your specified vote table to a file
+    to reuse at a later time,
+    so you won't have to pick this in every time.
+  </p>
+  <p>
+    Alternatively, you can upload a file
+    to automatically populate the vote table,
+    for example from a previously saved vote table.
+    In addition, you can choose from among some
+    predefined vote tables to load.
+    For your convenience, we have supplied results
+    from all Icelandic elections of the current century.
   </p>
 
-  <div style="text-align: center;">
-    <b-button size="lg" href="#/election">Run a single election</b-button>
-  </div>
-
-  <h2>Simulate</h2>
+  <h3>Single Election</h3>
 
   <p>
-    The <b><a href="#/simulate">Simulate</a></b> function allows you to run hundreds or even thousands of elections, each differing slightly from the last, in order to gain insights into the behaviour of different <i>voting systems</i>.
+    <b>Single Election</b> allows you
+    to calculate the results of a single election.
   </p>
+  <p>
+    As you update the <b>electoral system settings</b> and <b>vote table</b>,
+    the result will be automatically calculated
+    and the results displayed below.
+  </p>
+  <p>
+    You can also download an .xlsx file with the results.
+  </p>
+
+  <h3>Simulation</h3>
 
   <p>
-    By setting up several different systems, you can <i>compare</i> the statistical behaviour to see which systems do best under certain test conditions. The results are displayed in the form of several different <b><a href="#/qualitymeasures">quality measures</a></b>, each with their own interpretation.
+    The <b>Simulation</b> function allows you
+    to run hundreds or even thousands of elections,
+    each differing slightly from the last,
+    in order to gain insights into the behaviour
+    of different <i>electoral systems</i>.
   </p>
-
   <p>
-    As with running a single election, you must provide information about the <b>constituencies</b> in the country, the <b>parties</b> running in the election, and the <b>votes</b> each party got in each constituency.
+    You must provide at least one <b>electoral system</b> to be considered,
+    but you can have as many as you'd like.
+    By setting up several different systems,
+    you can <i>compare</i> the statistical behaviour
+    to see which systems do best under certain test conditions.
+    The results are displayed in the form of
+    several different <b><a href="#/qualitymeasures">quality measures</a></b>,
+    each with their own interpretation.
   </p>
-
   <p>
-    In addition to this, you must provide at least one set of <b>election rules</b> to be considered, but you can have as many rules as you'd like.
+    The <b>vote table</b> you supply will be used
+    as a reference on which to base
+    the statistical distribution of the randomly generated votes
+    for each round of the simulation.
+    At the moment, the only implemented distribution is the beta distribution,
+    in which case the simulation votes are generated
+    by adding a random fluctuation to the votes for each candidate list,
+    such that the average will tend to coincide with
+    the votes from the supplied vote table.
   </p>
-
   <p>
-    When choosing the <i>election rules</i>, you have a lot of different options to choose from ─ for a deeper understanding of these, you should read our guides on <b><a href="#/dividers">divider rules</a></b> and <b><a href="#/adjustmentmethods">adjustment methods</a></b>.
+    In addition to this,
+    you must decide how many rounds of simulation to run.
+    A high number will take more time to calculate,
+    but provide more significance to the statistics.
+    For the beta distribution,
+    you can also specify how widely the random generated votes should fluctuate.
   </p>
-
-  <div style="text-align: center;">
-    <b-button size="lg" href="#/simulate">Run a simulation</b-button>
-  </div>
+  <p>
+    Once you start the simulation,
+    the results will be displayed below,
+    as well as some quality measures.
+  </p>
+  <p>
+    You can also download an .xlsx file with the results,
+    even while the simulation is still running
+    (it will just contain statistics on the simulation so far).
+  </p>
 
   <h2>Documentation</h2>
   <ul>

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -43,6 +43,7 @@ export default {
     return {
       server: {
         waitingForData: false,
+        errormsg: '',
         error: false,
       },
       vote_table: {

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -4,6 +4,30 @@
     <b-alert :show="server.error" dismissible @dismissed="server.error=false" variant="danger">Server error. Try again in a few seconds...</b-alert>
     <b-alert :show="server.errormsg != ''" dismissible @dismissed="server.errormsg=''" variant="danger">Server error. {{server.errormsg}}</b-alert>
 
+    <h2>Electoral system settings</h2>
+    <b-card no-body>
+      <b-tabs v-model="activeTabIndex" card>
+        <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
+          <div slot="title">
+            <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
+            {{rulesidx}}-{{rules.name}}
+          </div>
+          <ElectionSettings
+            :rulesidx="rulesidx"
+            :rules="rules"
+            @update-rules="updateElectionRules">
+          </ElectionSettings>
+        </b-tab>
+        <template slot="tabs">
+          <b-button size="sm" @click="addElectionRules"><b>+</b></b-button>
+        </template>
+        <div slot="empty">
+          There are no electoral systems specified.
+          Use the <b>+</b> button to create a new electoral system.
+        </div>
+      </b-tabs>
+    </b-card>
+
     <h2>Votes</h2>
     <VoteMatrix
       @update-vote-table="updateVoteTable"
@@ -15,6 +39,7 @@
         <Election
           :vote_table="vote_table"
           :election_rules="election_rules"
+          :activeTabIndex="activeTabIndex"
           :server="server">
         </Election>
       </b-tab>
@@ -33,10 +58,12 @@
 import Election from './Election.vue'
 import Simulate from './Simulate.vue'
 import VoteMatrix from './components/VoteMatrix.vue'
+import ElectionSettings from './components/ElectionSettings.vue'
 
 export default {
   components: {
     VoteMatrix,
+    ElectionSettings,
     Election,
     Simulate,
   },
@@ -55,6 +82,7 @@ export default {
         votes: [],
       },
       election_rules: [{}],
+      activeTabIndex: 0,
       simulation_rules: {
         simulation_count: 0,
         gen_method: "",
@@ -70,6 +98,16 @@ export default {
     }
   },
   methods: {
+    addElectionRules: function() {
+      this.election_rules.push({})
+    },
+    deleteElectionRules: function(idx) {
+      this.election_rules.splice(idx, 1);
+    },
+    updateElectionRules: function(rules, idx) {
+      this.$set(this.election_rules, idx, rules);
+      //this works too: this.election_rules.splice(idx, 1, rules);
+    },
     updateVoteTable: function(table) {
       this.vote_table = table;
     },

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <b-alert :show="server.waitingForData">Loading...</b-alert>
+    <b-alert :show="server.error" dismissible @dismissed="server.error=false" variant="danger">Server error. Try again in a few seconds...</b-alert>
+    <b-alert :show="server.errormsg != ''" dismissible @dismissed="server.errormsg=''" variant="danger">Server error. {{server.errormsg}}</b-alert>
+
+    <h2>Votes</h2>
+    <VoteMatrix
+      @update-vote-table="updateVoteTable"
+      @server-error="serverError">
+    </VoteMatrix>
+
+    <b-tabs>
+      <b-tab title="Single Election" active>
+        <Election
+          :vote_table="vote_table"
+          :server="server">
+        </Election>
+      </b-tab>
+      <b-tab title="Simulation">
+        <Simulate
+          :vote_table="vote_table"
+          :server="server">
+        </Simulate>
+      </b-tab>
+    </b-tabs>
+  </div>
+</template>
+
+<script>
+import Election from './Election.vue'
+import Simulate from './Simulate.vue'
+import VoteMatrix from './components/VoteMatrix.vue'
+
+export default {
+  components: {
+    VoteMatrix,
+    Election,
+    Simulate,
+  },
+
+  data: function() {
+    return {
+      server: {
+        waitingForData: false,
+        error: false,
+      },
+      vote_table: {
+        name: "",
+        parties: [],
+        constituencies: [],
+        votes: [],
+      },
+      election_rules: [
+        {
+          name: "",
+          adjustment_divider: "",
+          primary_divider: "",
+          adjustment_threshold: 0.0,
+          adjustment_method: "",
+        }
+      ],
+      simulation_rules: {
+        simulation_count: 0,
+        gen_method: "",
+        distribution_parameter: 0,
+      },
+      simulation_results: {
+        done: true,
+        current_iteration: 0,
+        iteration_time: 0,
+        inflight: 0,
+      },
+      //results: { measures: [], methods: [], data: [] },
+    }
+  },
+  methods: {
+    updateVoteTable: function(table) {
+      this.vote_table = table;
+    },
+    updateVoteTable: function(table, recalc) {
+      this.vote_table = table;
+      if (recalc === true || recalc === undefined) {
+        this.recalculate();
+      }
+    },
+    serverError: function(error) {
+      this.server.errormsg = error;
+    },
+  }
+}
+</script>

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -51,15 +51,13 @@ export default {
         constituencies: [],
         votes: [],
       },
-      election_rules: [
-        {
-          name: "",
-          adjustment_divider: "",
-          primary_divider: "",
-          adjustment_threshold: 0.0,
-          adjustment_method: "",
-        }
-      ],
+      election_rules: [{
+        name: "",
+        adjustment_divider: "",
+        primary_divider: "",
+        adjustment_threshold: 0.0,
+        adjustment_method: "",
+      }],
       simulation_rules: {
         simulation_count: 0,
         gen_method: "",
@@ -77,12 +75,6 @@ export default {
   methods: {
     updateVoteTable: function(table) {
       this.vote_table = table;
-    },
-    updateVoteTable: function(table, recalc) {
-      this.vote_table = table;
-      if (recalc === true || recalc === undefined) {
-        this.recalculate();
-      }
     },
     serverError: function(error) {
       this.server.errormsg = error;

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -34,7 +34,7 @@
       @server-error="serverError">
     </VoteMatrix>
 
-    <b-tabs>
+    <b-tabs style="margin-top:10px">
       <b-tab title="Single Election" active>
         <Election
           :vote_table="vote_table"

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -14,12 +14,14 @@
       <b-tab title="Single Election" active>
         <Election
           :vote_table="vote_table"
+          :election_rules="election_rules"
           :server="server">
         </Election>
       </b-tab>
       <b-tab title="Simulation">
         <Simulate
           :vote_table="vote_table"
+          :election_rules="election_rules"
           :server="server">
         </Simulate>
       </b-tab>
@@ -52,13 +54,7 @@ export default {
         constituencies: [],
         votes: [],
       },
-      election_rules: [{
-        name: "",
-        adjustment_divider: "",
-        primary_divider: "",
-        adjustment_threshold: 0.0,
-        adjustment_method: "",
-      }],
+      election_rules: [{}],
       simulation_rules: {
         simulation_count: 0,
         gen_method: "",

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -10,7 +10,7 @@
         <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
           <div slot="title">
             <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
-            {{rulesidx}}-{{rules.name}}
+            {{rulesidx+1}}-{{rules.name}}
           </div>
           <ElectionSettings
             :rulesidx="rulesidx"

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -120,6 +120,7 @@ import SimulationData from './components/SimulationData.vue'
 export default {
   props: {
     "vote_table": { default: {} },
+    "election_rules": { default: [{}] },
     "server": { default: {} },
   },
   components: {
@@ -133,7 +134,6 @@ export default {
   data: function() {
     return {
       distribution_parameter: 0,
-      election_rules: [{}],
       simulation_rules: {
         simulation_count: 0,
         gen_method: "",

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -10,7 +10,10 @@
             <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
             {{rulesidx}}-{{rules.name}}
           </div>
-          <ElectionSettings :rulesidx="rulesidx" @update-rules="updateElectionRules">
+          <ElectionSettings
+            :rulesidx="rulesidx"
+            :rules="rules"
+            @update-rules="updateElectionRules">
           </ElectionSettings>
         </b-tab>
         <template slot="tabs">

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -6,8 +6,6 @@
     <VoteMatrix
       @update-table-name="updateTableName"
       @update-votes="updateVotes"
-      @update-adjustment-seats="updateAdjustmentSeats"
-      @update-constituency-seats="updateConstituencySeats"
       @update-parties="updateParties"
       @update-constituencies="updateConstituencies"
       @server-error="serverError">
@@ -134,10 +132,8 @@ export default {
         error: false,
       },
       distribution_parameter: 0,
-      constituency_names: [],
       parties: [],
-      constituency_seats: [],
-      constituency_adjustment_seats: [],
+      constituencies: [],
       election_rules: [
         {
           name: "",
@@ -190,14 +186,8 @@ export default {
     updateVotes: function(votes) {
       this.ref_votes = votes;
     },
-    updateConstituencySeats: function(seats) {
-      this.constituency_seats = seats;
-    },
-    updateAdjustmentSeats: function(seats) {
-      this.constituency_adjustment_seats = seats;
-    },
     updateConstituencies: function(cons) {
-      this.constituency_names = cons;
+      this.constituencies = cons;
     },
     updateParties: function(parties) {
       this.parties = parties;
@@ -267,9 +257,7 @@ export default {
         {
           vote_table: {
             name: this.table_name,
-            constituency_names: this.constituency_names,
-            constituency_seats: this.constituency_seats,
-            constituency_adjustment_seats: this.constituency_adjustment_seats,
+            constituencies: this.constituencies,
             parties: this.parties,
             votes: this.ref_votes
           },

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -166,7 +166,8 @@ export default {
       this.election_rules.splice(idx, 1);
     },
     updateElectionRules: function(rules, idx) {
-      this.election_rules[idx] = rules;
+      this.$set(this.election_rules, idx, rules);
+      //this works too: this.election_rules.splice(idx, 1, rules);
     },
     updateSimulationRules: function(rules) {
       this.simulation_rules = rules;

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -3,18 +3,25 @@
     <h1>Simulate elections</h1>
 
     <h2>Electoral system settings</h2>
-    <b-button @click="addElectionRules">Add electoral system</b-button>
-    <b-container v-for="(rules, rulesidx) in election_rules" :key="rulesidx" class="ruleset">
-      <b-row>
-        <b-col cols="10">
+    <b-card no-body>
+      <b-tabs card>
+        <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
+          <div slot="title">
+            <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
+            {{rulesidx}}-{{rules.name}}
+          </div>
           <ElectionSettings :rulesidx="rulesidx" @update-rules="updateElectionRules">
           </ElectionSettings>
-        </b-col>
-        <b-col>
-          <b-button @click="deleteElectionRules(rulesidx)">Delete this system</b-button>
-        </b-col>
-      </b-row>
-    </b-container>
+        </b-tab>
+        <template slot="tabs">
+          <b-button size="sm" @click="addElectionRules"><b>+</b></b-button>
+        </template>
+        <div slot="empty">
+          There are no electoral systems specified.
+          Use the + button to create a new electoral system.
+        </div>
+      </b-tabs>
+    </b-card>
 
     <h2>Simulation settings</h2>
     <SimulationSettings

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -1,7 +1,5 @@
 <template>
   <div>
-    <h1>Simulate elections</h1>
-
     <h2>Simulation settings</h2>
     <SimulationSettings
       @update-rules="updateSimulationRules"

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -4,10 +4,7 @@
 
     <h2>Votes</h2>
     <VoteMatrix
-      @update-table-name="updateTableName"
-      @update-votes="updateVotes"
-      @update-parties="updateParties"
-      @update-constituencies="updateConstituencies"
+      @update-vote-table="updateVoteTable"
       @server-error="serverError">
     </VoteMatrix>
 
@@ -132,8 +129,12 @@ export default {
         error: false,
       },
       distribution_parameter: 0,
-      parties: [],
-      constituencies: [],
+      vote_table: {
+        name: "",
+        votes: [],
+        parties: [],
+        constituencies: [],
+      },
       election_rules: [
         {
           name: "",
@@ -151,8 +152,6 @@ export default {
       current_iteration: 0,
       iteration_time: 0,
       inflight: 0,
-      table_name: "",
-      ref_votes: [],
       results: { measures: [], methods: [], data: [] },
     }
   },
@@ -180,17 +179,8 @@ export default {
     updateDistributionParameter: function(parameter) {
       this.distribution_parameter = parameter
     },
-    updateTableName: function(name) {
-      this.table_name = name;
-    },
-    updateVotes: function(votes) {
-      this.ref_votes = votes;
-    },
-    updateConstituencies: function(cons) {
-      this.constituencies = cons;
-    },
-    updateParties: function(parties) {
-      this.parties = parties;
+    updateVoteTable: function(table) {
+      this.vote_table = table;
     },
     serverError: function(error) {
       this.server.errormsg = error;
@@ -255,12 +245,7 @@ export default {
       this.server.waitingForData = true;
       this.$http.post('/api/simulate/',
         {
-          vote_table: {
-            name: this.table_name,
-            constituencies: this.constituencies,
-            parties: this.parties,
-            votes: this.ref_votes
-          },
+          vote_table: this.vote_table,
           election_rules: this.election_rules,
           simulation_rules: this.simulation_rules,
           stbl_param: this.distribution_parameter

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -2,30 +2,6 @@
   <div>
     <h1>Simulate elections</h1>
 
-    <h2>Electoral system settings</h2>
-    <b-card no-body>
-      <b-tabs card>
-        <b-tab v-for="(rules, rulesidx) in election_rules" :key="rulesidx">
-          <div slot="title">
-            <b-button size="sm" variant="link" @click="deleteElectionRules(rulesidx)">x</b-button>
-            {{rulesidx}}-{{rules.name}}
-          </div>
-          <ElectionSettings
-            :rulesidx="rulesidx"
-            :rules="rules"
-            @update-rules="updateElectionRules">
-          </ElectionSettings>
-        </b-tab>
-        <template slot="tabs">
-          <b-button size="sm" @click="addElectionRules"><b>+</b></b-button>
-        </template>
-        <div slot="empty">
-          There are no electoral systems specified.
-          Use the + button to create a new electoral system.
-        </div>
-      </b-tabs>
-    </b-card>
-
     <h2>Simulation settings</h2>
     <SimulationSettings
       @update-rules="updateSimulationRules"
@@ -111,9 +87,7 @@
 </template>
 
 <script>
-import VoteMatrix from './components/VoteMatrix.vue'
 import ResultMatrix from './components/ResultMatrix.vue'
-import ElectionSettings from './components/ElectionSettings.vue'
 import SimulationSettings from './components/SimulationSettings.vue'
 import SimulationData from './components/SimulationData.vue'
 
@@ -124,9 +98,7 @@ export default {
     "server": { default: {} },
   },
   components: {
-    VoteMatrix,
     ResultMatrix,
-    ElectionSettings,
     SimulationSettings,
     SimulationData,
   },
@@ -146,16 +118,6 @@ export default {
     }
   },
   methods: {
-    addElectionRules: function() {
-      this.election_rules.push({})
-    },
-    deleteElectionRules: function(idx) {
-      this.election_rules.splice(idx, 1);
-    },
-    updateElectionRules: function(rules, idx) {
-      this.$set(this.election_rules, idx, rules);
-      //this works too: this.election_rules.splice(idx, 1, rules);
-    },
     updateSimulationRules: function(rules) {
       this.simulation_rules = rules;
     },

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -133,15 +133,7 @@ export default {
   data: function() {
     return {
       distribution_parameter: 0,
-      election_rules: [
-        {
-          name: "",
-          adjustment_divider: "",
-          primary_divider: "",
-          adjustment_threshold: 0.0,
-          adjustment_method: "",
-        }
-      ],
+      election_rules: [{}],
       simulation_rules: {
         simulation_count: 0,
         gen_method: "",
@@ -155,15 +147,7 @@ export default {
   },
   methods: {
     addElectionRules: function() {
-      this.election_rules.push(
-        {
-          name: "",
-          adjustment_divider: "",
-          primary_divider: "",
-          adjustment_threshold: 0.0,
-          adjustment_method: "",
-        }
-      )
+      this.election_rules.push({})
     },
     deleteElectionRules: function(idx) {
       this.election_rules.splice(idx, 1);

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -63,8 +63,8 @@
       <h3>Constituency seats</h3>
       <ResultMatrix v-for="(ruleset, idx) in results.data"
         :key="'const-seats-' + idx"
-        :constituencies="constituency_names"
-        :parties="parties"
+        :constituencies="vote_table.constituencies"
+        :parties="vote_table.parties"
         :values="ruleset.list_measures.const_seats.avg"
         :stddev="ruleset.list_measures.const_seats.std"
         :title="ruleset.name"
@@ -74,8 +74,8 @@
       <h3>Adjustment seats</h3>
       <ResultMatrix v-for="(ruleset, idx) in results.data"
         :key="'adj-seats-' + idx"
-        :constituencies="constituency_names"
-        :parties="parties"
+        :constituencies="vote_table.constituencies"
+        :parties="vote_table.parties"
         :values="ruleset.list_measures.adj_seats.avg"
         :stddev="ruleset.list_measures.adj_seats.std"
         :title="ruleset.name"
@@ -85,8 +85,8 @@
       <h3>Total seats</h3>
       <ResultMatrix v-for="(ruleset, idx) in results.data"
         :key="'total-seats-' + idx"
-        :constituencies="constituency_names"
-        :parties="parties"
+        :constituencies="vote_table.constituencies"
+        :parties="vote_table.parties"
         :values="ruleset.list_measures.total_seats.avg"
         :stddev="ruleset.list_measures.total_seats.std"
         :title="ruleset.name"

--- a/vue-frontend/src/Simulate.vue
+++ b/vue-frontend/src/Simulate.vue
@@ -2,12 +2,6 @@
   <div>
     <h1>Simulate elections</h1>
 
-    <h2>Votes</h2>
-    <VoteMatrix
-      @update-vote-table="updateVoteTable"
-      @server-error="serverError">
-    </VoteMatrix>
-
     <h2>Electoral system settings</h2>
     <b-button @click="addElectionRules">Add electoral system</b-button>
     <b-container v-for="(rules, rulesidx) in election_rules" :key="rulesidx" class="ruleset">
@@ -114,6 +108,10 @@ import SimulationSettings from './components/SimulationSettings.vue'
 import SimulationData from './components/SimulationData.vue'
 
 export default {
+  props: {
+    "vote_table": { default: {} },
+    "server": { default: {} },
+  },
   components: {
     VoteMatrix,
     ResultMatrix,
@@ -124,17 +122,7 @@ export default {
 
   data: function() {
     return {
-      server: {
-        waitingForData: false,
-        error: false,
-      },
       distribution_parameter: 0,
-      vote_table: {
-        name: "",
-        votes: [],
-        parties: [],
-        constituencies: [],
-      },
       election_rules: [
         {
           name: "",
@@ -178,12 +166,6 @@ export default {
     },
     updateDistributionParameter: function(parameter) {
       this.distribution_parameter = parameter
-    },
-    updateVoteTable: function(table) {
-      this.vote_table = table;
-    },
-    serverError: function(error) {
-      this.server.errormsg = error;
     },
     stop_simulation: function() {
       this.$http.post('/api/simulate/stop/',

--- a/vue-frontend/src/app.js
+++ b/vue-frontend/src/app.js
@@ -10,14 +10,12 @@ import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
 
 import App from './App.vue'
-import Election from './Election.vue'
-import Simulate from './Simulate.vue'
+import Main from './Main.vue'
 import Intro from './Intro.vue'
 
 const routes = [
   { path: '/', component: Intro },
-  { path: '/election', component: Election },
-  { path: '/simulate', component: Simulate }
+  { path: '/main', component: Main }
 ]
 
 var router = new VueRouter({ routes })

--- a/vue-frontend/src/app.js
+++ b/vue-frontend/src/app.js
@@ -15,7 +15,7 @@ import Intro from './Intro.vue'
 
 const routes = [
   { path: '/', component: Intro },
-  { path: '/main', component: Main }
+  { path: '/calc', component: Main }
 ]
 
 var router = new VueRouter({ routes })

--- a/vue-frontend/src/components/ElectionSettings.vue
+++ b/vue-frontend/src/components/ElectionSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <b-form>
-    <b-row v-if="rulesidx !== undefined">
+    <b-row>
       <b-col>
         <b-form-group
           label="Name"
@@ -79,10 +79,9 @@ export default {
   },
   created: function() {
     this.$http.get('/api/capabilities').then(response => {
-      this.rules = response.body.election_rules;
       this.capabilities = response.body.capabilities;
+      this.$emit('update-rules', response.body.election_rules, this.rulesidx);
       this.doneCreating = true;
-      this.$emit('update-rules', this.rules, this.rulesidx);
     }, response => {
       this.serverError = true;
     });

--- a/vue-frontend/src/components/ElectionSettings.vue
+++ b/vue-frontend/src/components/ElectionSettings.vue
@@ -11,44 +11,67 @@
       </b-col>
     </b-row>
     <b-row>
+      <legend>Allocation of constituency seats</legend>
       <b-col>
         <b-form-group
-          label="Rule for allocating constituency seats"
+          label="Threshold"
+          description="What threshold are parties required to reach within a particular constituency to qualify for constituency seats?">
+          <b-input-group append="%">
+            <b-form-input type="number" min="0" max="100"
+              v-model.number="rules.constituency_threshold"/>
+          </b-input-group>
+        </b-form-group>
+      </b-col>
+      <b-col>
+        <b-form-group
+          label="Rule"
           description="Which rule should be used to allocate constituency seats to lists within each constituency?">
           <b-form-select class="mb-3"
             v-model="rules.primary_divider"
             :options="capabilities.divider_rules"/>
         </b-form-group>
+      </b-col>
+    </b-row>
+    <b-row>
+      <legend>Division of adjustment seats</legend>
+      <b-col>
         <b-form-group
-          label="Rule for dividing adjustment seats"
-          description="Which rule should be used to divide adjustment seats between parties?">
-          <b-form-select class="mb-3"
-            v-model="rules.adj_determine_divider"
-            :options="capabilities.divider_rules"/>
-        </b-form-group>
-        <b-form-group
-          label="Rule for allocating adjustment seats"
-          description="Which rule should be used to allocate adjustment seats to individual lists?">
-          <b-form-select class="mb-3"
-            v-model="rules.adj_alloc_divider"
-            :options="capabilities.divider_rules"/>
+          label="Threshold"
+          description="What threshold are parties required to reach nationally to qualify for adjustment seats?">
+          <b-input-group append="%">
+            <b-form-input type="number" min="0" max="100"
+              v-model.number="rules.adjustment_threshold"/>
+          </b-input-group>
         </b-form-group>
       </b-col>
       <b-col>
         <b-form-group
-          label="Adjustment method"
+          label="Rule"
+          description="Which rule should be used to divide adjustment seats between parties nationally?">
+          <b-form-select class="mb-3"
+            v-model="rules.adj_determine_divider"
+            :options="capabilities.divider_rules"/>
+        </b-form-group>
+      </b-col>
+    </b-row>
+    <b-row>
+      <legend>Allocation of adjustment seats</legend>
+      <b-col>
+        <b-form-group
+          label="Method"
           description="Which method should be used to allocate adjustment seats?">
           <b-form-select class="mb-3"
             v-model="rules.adjustment_method"
             :options="capabilities.adjustment_methods"/>
         </b-form-group>
+      </b-col>
+      <b-col>
         <b-form-group
-          label="Adjustment threshold"
-          description="What threshold are parties required to reach to qualify for adjustment seats?">
-          <b-input-group append="%">
-            <b-form-input type="number" min="0" max="100"
-              v-model.number="rules.adjustment_threshold"/>
-          </b-input-group>
+          label="Rule"
+          description="Which rule should be used to allocate adjustment seats to individual lists?">
+          <b-form-select class="mb-3"
+            v-model="rules.adj_alloc_divider"
+            :options="capabilities.divider_rules"/>
         </b-form-group>
       </b-col>
     </b-row>

--- a/vue-frontend/src/components/ElectionSettings.vue
+++ b/vue-frontend/src/components/ElectionSettings.vue
@@ -6,7 +6,7 @@
           label="Name"
           description="Give this electoral system a name.">
           <b-form-input type="text" class="mb-3"
-            v-model="rules.election_rules.name"/>
+            v-model="rules.name"/>
         </b-form-group>
       </b-col>
     </b-row>
@@ -16,22 +16,22 @@
           label="Rule for allocating constituency seats"
           description="Which rule should be used to allocate constituency seats to lists within each constituency?">
           <b-form-select class="mb-3"
-            v-model="rules.election_rules.primary_divider"
-            :options="rules.capabilities.divider_rules"/>
+            v-model="rules.primary_divider"
+            :options="capabilities.divider_rules"/>
         </b-form-group>
         <b-form-group
           label="Rule for dividing adjustment seats"
           description="Which rule should be used to divide adjustment seats between parties?">
           <b-form-select class="mb-3"
-            v-model="rules.election_rules.adj_determine_divider"
-            :options="rules.capabilities.divider_rules"/>
+            v-model="rules.adj_determine_divider"
+            :options="capabilities.divider_rules"/>
         </b-form-group>
         <b-form-group
           label="Rule for allocating adjustment seats"
           description="Which rule should be used to allocate adjustment seats to individual lists?">
           <b-form-select class="mb-3"
-            v-model="rules.election_rules.adj_alloc_divider"
-            :options="rules.capabilities.divider_rules"/>
+            v-model="rules.adj_alloc_divider"
+            :options="capabilities.divider_rules"/>
         </b-form-group>
       </b-col>
       <b-col>
@@ -39,15 +39,15 @@
           label="Adjustment method"
           description="Which method should be used to allocate adjustment seats?">
           <b-form-select class="mb-3"
-            v-model="rules.election_rules.adjustment_method"
-            :options="rules.capabilities.adjustment_methods"/>
+            v-model="rules.adjustment_method"
+            :options="capabilities.adjustment_methods"/>
         </b-form-group>
         <b-form-group
           label="Adjustment threshold"
           description="What threshold are parties required to reach to qualify for adjustment seats?">
           <b-input-group append="%">
-            <b-form-input type="number" min="0" max="100" 
-              v-model.number="rules.election_rules.adjustment_threshold"/>
+            <b-form-input type="number" min="0" max="100"
+              v-model.number="rules.adjustment_threshold"/>
           </b-input-group>
         </b-form-group>
       </b-col>
@@ -61,14 +61,15 @@ export default {
   data: function () {
     return {
       doneCreating: false,
-      rules: { capabilities: {}, election_rules: { } },
+      rules: { },
+      capabilities: {},
     }
   },
   watch: {
     'rules': {
       handler: function (val, oldVal) {
         if (this.doneCreating) {
-          this.$emit('update-rules', val.election_rules, this.rulesidx);
+          this.$emit('update-rules', val, this.rulesidx);
         }
       },
       deep: true
@@ -76,7 +77,8 @@ export default {
   },
   created: function() {
     this.$http.get('/api/capabilities').then(response => {
-      this.rules = response.body;
+      this.rules = response.body.election_rules;
+      this.capabilities = response.body.capabilities;
       this.doneCreating = true;
     }, response => {
       this.serverError = true;

--- a/vue-frontend/src/components/ElectionSettings.vue
+++ b/vue-frontend/src/components/ElectionSettings.vue
@@ -80,6 +80,7 @@ export default {
       this.rules = response.body.election_rules;
       this.capabilities = response.body.capabilities;
       this.doneCreating = true;
+      this.$emit('update-rules', this.rules, this.rulesidx);
     }, response => {
       this.serverError = true;
     });

--- a/vue-frontend/src/components/ElectionSettings.vue
+++ b/vue-frontend/src/components/ElectionSettings.vue
@@ -57,11 +57,13 @@
 
 <script>
 export default {
-  props: [ "rulesidx" ],
+  props: [
+    "rulesidx",
+    "rules",
+  ],
   data: function () {
     return {
       doneCreating: false,
-      rules: { },
       capabilities: {},
     }
   },

--- a/vue-frontend/src/components/ResultChart.vue
+++ b/vue-frontend/src/components/ResultChart.vue
@@ -32,12 +32,7 @@ export default {
   },
   computed: {
     chartData() {
-      let seats = Array(this.parties.length).fill(0);
-      for (let c in this.seats) {
-        seats = this.seats[c].map(function (num, idx) {
-          return seats[idx]+num;
-        });
-      }
+      let seats = this.seats[this.seats.length-1].slice(0, -1);
       return {
         labels: this.parties,
         datasets: [

--- a/vue-frontend/src/components/ResultChart.vue
+++ b/vue-frontend/src/components/ResultChart.vue
@@ -24,7 +24,11 @@ export default {
     parties: function() {
       if (this._chart) this._chart.destroy();
       this.renderResultChart();
-    }
+    },
+    seats: function() {
+      if (this._chart) this._chart.destroy();
+      this.renderResultChart();
+    },
   },
   computed: {
     chartData() {

--- a/vue-frontend/src/components/ResultMatrix.vue
+++ b/vue-frontend/src/components/ResultMatrix.vue
@@ -22,7 +22,7 @@
       </tr>
       <tr v-for="(constituency, conidx) in constituencies">
         <th class="small-12 medium-1 column constname">
-          {{ constituencies[conidx] }}
+          {{ constituency["name"] }}
         </th>
         <template v-for="(party, partyidx) in parties">
           <td class="small-12 medium-2 column partyseats">

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -57,19 +57,32 @@
 
     <b-button-toolbar key-nav aria-label="Vote tools">
       <b-button-group class="mx-1">
-        <b-button v-b-modal.modalpreset>Load preset</b-button>
-        <b-button v-b-modal.modalupload>Upload votes</b-button>
-        <b-button v-b-modal.modalpaste>Paste input</b-button>
+        <b-button title="Load existing vote table from server"
+          v-b-modal.modalpreset>Load preset
+        </b-button>
+        <b-button title="Upload vote table file (.xlsx or .csv)"
+          v-b-modal.modalupload>Upload votes
+        </b-button>
+        <b-button title="Paste input from file with csv format"
+          v-b-modal.modalpaste>Paste input
+        </b-button>
         <!--b-dropdown id="ddown1" text="Presets" size="sm">
           <b-dropdown-item v-for="(preset, presetidx) in presets" :key="preset.name" @click="setPreset(presetidx)">{{preset.name}}</b-dropdown-item>
         </b-dropdown-->
       </b-button-group>
       <b-button-group class="mx-1">
-        <b-button @click="saveVotes()">Save voteset</b-button>
+        <b-button title="Download .xlsx file with vote table"
+          @click="saveVotes()">Save votes
+        </b-button>
       </b-button-group>
       <b-button-group class="mx-1">
-        <b-btn @click="clearVotes()">Clear votes</b-btn>
-        <b-btn @click="clearAll()">Delete table</b-btn>
+        <b-btn title="set all vote counts to zero but preserve frame"
+          @click="clearVotes()">Clear votes
+        </b-btn>
+        <b-btn
+          title="Empty entire table and remove all parties and constituencies"
+          @click="clearAll()">Delete table
+        </b-btn>
       </b-button-group>
     </b-button-toolbar>
     <table class="votematrix">

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -45,7 +45,6 @@
     </b-modal>
 
     <b-modal size="lg" id="modalpreset" ref="modalpresetref" title="Load preset" cancel-only>
-
       <b-table hover :items="presets" :fields="presetfields">
         <template slot="actions" slot-scope="row">
           <b-button size="sm" @click.stop="loadPreset(row.item.id); $refs.modalpresetref.hide()" class="mr-1 mt-0 mb-0">
@@ -66,9 +65,6 @@
         <b-button title="Paste input from file with csv format"
           v-b-modal.modalpaste>Paste input
         </b-button>
-        <!--b-dropdown id="ddown1" text="Presets" size="sm">
-          <b-dropdown-item v-for="(preset, presetidx) in presets" :key="preset.name" @click="setPreset(presetidx)">{{preset.name}}</b-dropdown-item>
-        </b-dropdown-->
       </b-button-group>
       <b-button-group class="mx-1">
         <b-button title="Download .xlsx file with vote table"
@@ -225,12 +221,6 @@ export default {
       this.$http.post('/api/presets/load/', {'eid': eid}).then(response => {
         this.matrix = response.data;
       })
-    },
-    setPreset: function(idx) {
-      let el = this.presets[idx].election_rules;
-      this.matrix.constituencies = el.constituencies;
-      this.matrix.parties = el.parties;
-      this.matrix.votes = el.votes;
     },
     uploadVotes: function(evt) {
       if (!this.uploadfile) {

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -57,19 +57,19 @@
 
     <b-button-toolbar key-nav aria-label="Vote tools">
       <b-button-group class="mx-1">
-        <b-btn @click="clearVotes()">Clear votes</b-btn>
-        <b-btn @click="clearAll()">Reset everything</b-btn>
-      </b-button-group>
-      <b-button-group class="mx-1">
+        <b-button v-b-modal.modalpreset>Load preset</b-button>
         <b-button v-b-modal.modalupload>Upload votes</b-button>
         <b-button v-b-modal.modalpaste>Paste input</b-button>
-        <b-button v-b-modal.modalpreset>Load preset</b-button>
         <!--b-dropdown id="ddown1" text="Presets" size="sm">
           <b-dropdown-item v-for="(preset, presetidx) in presets" :key="preset.name" @click="setPreset(presetidx)">{{preset.name}}</b-dropdown-item>
         </b-dropdown-->
       </b-button-group>
       <b-button-group class="mx-1">
         <b-button @click="saveVotes()">Save voteset</b-button>
+      </b-button-group>
+      <b-button-group class="mx-1">
+        <b-btn @click="clearVotes()">Clear votes</b-btn>
+        <b-btn @click="clearAll()">Delete table</b-btn>
       </b-button-group>
     </b-button-toolbar>
     <table class="votematrix">

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -96,7 +96,7 @@
           <b-button size="sm" variant="link" @click="deleteParty(partyidx)">×</b-button>
           <input type="text" v-model="matrix.parties[partyidx]">
         </th>
-        <th>
+        <th class="growtable">
           <b-btn size="sm" @click="addParty()"><b>+</b></b-btn>
         </th>
       </tr>
@@ -117,7 +117,7 @@
         </td>
       </tr>
       <tr>
-        <th>
+        <th class="growtable">
           <b-btn size="sm" @click="addConstituency()"><b>+</b></b-btn>
         </th>
       </tr>

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -210,11 +210,15 @@ export default {
       this.$http.post('/api/votes/save/', {
         vote_table: this.matrix
       }).then(response => {
-        let link = document.createElement('a')
-        link.href = '/api/downloads/get?id=' + response.data.download_id
-        link.click()
+        if (response.body.error) {
+          this.$emit('server-error', response.body.error);
+        } else {
+          let link = document.createElement('a')
+          link.href = '/api/downloads/get?id=' + response.data.download_id
+          link.click()
+        }
       }, response => {
-        this.server.error = true;
+        console.log("Error:", response);
       })
     },
     loadPreset: function(eid) {

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -57,8 +57,6 @@
 
     <b-button-toolbar key-nav aria-label="Vote tools">
       <b-button-group class="mx-1">
-        <b-btn @click="addConstituency()">Add constituency</b-btn>
-        <b-btn @click="addParty()">Add party</b-btn>
         <b-btn @click="clearVotes()">Clear votes</b-btn>
         <b-btn @click="clearAll()">Reset everything</b-btn>
       </b-button-group>
@@ -89,6 +87,9 @@
           <b-button size="sm" variant="link" @click="deleteParty(partyidx)">×</b-button>
           <input type="text" v-model="matrix.parties[partyidx]">
         </th>
+        <th>
+          <b-btn size="sm" @click="addParty()"><b>+</b></b-btn>
+        </th>
       </tr>
       <tr v-for="(constituency, conidx) in matrix.constituencies">
         <th class="small-12 medium-1 column constname">
@@ -105,6 +106,11 @@
             <input type="text" v-model.number="matrix.votes[conidx][partyidx]">
             </input>
         </td>
+      </tr>
+      <tr>
+        <th>
+          <b-btn size="sm" @click="addConstituency()"><b>+</b></b-btn>
+        </th>
       </tr>
     </table>
   </b-container>

--- a/vue-frontend/static/css/app.css
+++ b/vue-frontend/static/css/app.css
@@ -67,6 +67,11 @@ th.topleft {
   background:     #ddd;
 }
 
+.growtable {
+  border: 0px !important;
+  background-color: #fff;
+}
+
 .resultmatrix tr:nth-child(even) {
     background-color: #f2f2f2;
 }


### PR DESCRIPTION
- Let Single Election and Simulation share the same vote table
- Change presentation of electoral system settings to tab representation, such that only one system is active at once
- Allow multiple electoral systems for Single Election as well as Simulation
- Let Single Election and Simulation share electoral system settings
- Add constituency threshold option to interface (and implementation)
- Evolve code structure
- - Most notably, information about constituencies (name, number of constituency seats and number of adjustment seats) is now represented in a single list of dictionaries, where each element has the three respective properties, rather than being represented as three separate lists that must be maintained together.
- Assorted minor fixes/improvements