### PR TITLE
Fix bug with icelandic law and update vue dependency

### DIFF
--- a/backend/apportion.py
+++ b/backend/apportion.py
@@ -66,6 +66,8 @@ def apportion1d_general(
         - allocations vector
         - a generator that generates a sequence of seat allocations,
         -  including vote values used.
+        - easy reference to the last seat to be allocated
+        - information about the first seat that was not allocated
     """
     N = len(v_votes)
     allocations = copy(prior_allocations) if prior_allocations else [0]*N

--- a/backend/apportion.py
+++ b/backend/apportion.py
@@ -2,7 +2,7 @@ from copy import copy
 from table_util import find_shares_1d
 
 def apportion1d(v_votes, num_total_seats, prior_allocations, divisor_gen,
-                threshold=0, invalid=[], v_max_left=[]):
+                threshold=0, v_max_left=[]):
     """
     Perform a one-dimensional apportionment of seats.
     Inputs:
@@ -10,8 +10,6 @@ def apportion1d(v_votes, num_total_seats, prior_allocations, divisor_gen,
         - num_total_seats: Total number of seats to allocate.
         - prior_allocations: Prior allocations to each party.
         - divisor_gen: A divisor generator function, e.g. Sainte-Lague.
-        - invalid: A list of parties that cannot be allocated more seats.
-            (Added for Icelandic law adjustment seat apportionment.)
     Outputs:
         - allocations vector
         - a tuple containing current divisors, divisor generators, and the
@@ -36,11 +34,9 @@ def apportion1d(v_votes, num_total_seats, prior_allocations, divisor_gen,
     min_used = 1000000
     while num_allocated < num_total_seats:
         divided_votes = [float(v_votes[i])/divisors[i]
-                         if v_max_left[i]>0 and i not in invalid else 0
+                         if v_max_left[i]>0 else 0
                          for i in range(N)]
         maxvote = max(divided_votes)
-        if maxvote == 0:
-            raise ValueError(f"No valid recipient of seat nr. {num_allocated+1}")
         min_used = maxvote
         maxparty = divided_votes.index(maxvote)
         divisors[maxparty] = next(divisor_gens[maxparty])
@@ -49,57 +45,6 @@ def apportion1d(v_votes, num_total_seats, prior_allocations, divisor_gen,
         v_max_left[maxparty] -= 1
 
     return allocations, (divisors, divisor_gens, min_used)
-
-def apportion1d_by_quota(
-    v_votes,
-    num_total_seats,
-    prior_allocations,
-    quota_rule,
-    threshold=0,
-):
-    """
-    Perform a one-dimensional apportionment of seats,
-    with the method of largest remainders.
-    Inputs:
-        - v_votes: Vector of votes to base the apportionment on.
-        - num_total_seats: Total number of seats to allocate.
-        - prior_allocations: Prior allocations to each party.
-        - quota_rule: A rule for calculating quota, e.g. Droop quota.
-    Outputs:
-        - allocations vector
-        - sequence of seat allocations, including vote values used.
-        - party with largest remainder not resulting in seat.
-    """
-    N = len(v_votes)
-    allocations = copy(prior_allocations) if prior_allocations else [0]*N
-    num_allocated = sum(allocations)
-    # v_max_left = copy(v_max_left) if v_max_left else [num_total_seats]*N
-
-    active_votes = threshold_elimination_1d(v_votes, threshold)
-    total_votes = sum(active_votes)
-    quota = quota_rule(total_votes, num_total_seats)
-
-    for n in range(N):
-        active_votes[n] -= quota*allocations[n]
-
-    allocation_sequence = []
-    while num_allocated < num_total_seats:
-        highest = active_votes.index(max(active_votes))
-        allocation_sequence.append({
-            "highest": highest,
-            "active_votes": active_votes[highest],
-        })
-        active_votes[highest] -= quota
-        allocations[highest] += 1
-        num_allocated += 1
-
-    highest = active_votes.index(max(active_votes))
-    next_in_line = {
-        "highest": highest,
-        "active_votes": active_votes[highest],
-    }
-
-    return allocations, allocation_sequence, next_in_line
 
 def apportion1d_general(
     v_votes,

--- a/backend/apportion.py
+++ b/backend/apportion.py
@@ -136,12 +136,15 @@ def apportion1d_general(
         type_of_rule=type_of_rule
     )
 
+    last_in = None
     gen = seat_gen()
     while sum(allocations) < num_total_seats:
         seat = next(gen)
         allocations[seat["idx"]] += 1
+        last_in = seat
+    next_in_line = next(gen)
 
-    return allocations, seat_gen
+    return allocations, seat_gen, last_in, next_in_line
 
 def seat_generator(
     votes,

--- a/backend/apportion.py
+++ b/backend/apportion.py
@@ -25,10 +25,7 @@ def apportion1d(v_votes, num_total_seats, prior_allocations, divisor_gen,
         divisors.append(x)
 
     allocations = copy(prior_allocations)
-    if v_max_left == []:
-        v_max_left = [num_total_seats]*len(v_votes)
-    else:
-        v_max_left = copy(v_max_left)
+    v_max_left = copy(v_max_left) if v_max_left else [num_total_seats]*N
 
     num_allocated = sum(prior_allocations)
     min_used = 1000000

--- a/backend/methods/icelandic_law.py
+++ b/backend/methods/icelandic_law.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 import random
 
-from apportion import apportion1d
+from apportion import apportion1d, apportion1d_by_quota
 
 def icelandic_apportionment(
     m_votes,

--- a/backend/methods/icelandic_law.py
+++ b/backend/methods/icelandic_law.py
@@ -4,9 +4,17 @@ import random
 
 from apportion import apportion1d
 
-def icelandic_apportionment(m_votes, v_desired_row_sums, v_desired_col_sums,
-                            m_prior_allocations, divisor_gen, threshold=None,
-                            orig_votes=None, **kwargs):
+def icelandic_apportionment(
+    m_votes,
+    v_desired_row_sums,
+    v_desired_col_sums,
+    m_prior_allocations,
+    divisor_gen,
+    sum_divisor_gen,
+    threshold=None,
+    orig_votes=None,
+    **kwargs
+):
     """
     Apportion based on Icelandic law nr. 24/2000.
     """
@@ -37,7 +45,7 @@ def icelandic_apportionment(m_votes, v_desired_row_sums, v_desired_col_sums,
     seats_info = []
     while num_allocated < total_seats:
         alloc, d = apportion1d(v_votes, num_allocated+1, v_last_alloc,
-                                divisor_gen, invalid=invalid)
+                                sum_divisor_gen, invalid=invalid)
         # 2.6.
         #   (Hafi allar hlutfallstölur stjórnmálasamtaka verið numdar brott
         #   skal jafnframt fella niður allar landstölur þeirra.)

--- a/backend/methods/icelandic_law_based_on_shares.py
+++ b/backend/methods/icelandic_law_based_on_shares.py
@@ -10,6 +10,7 @@ def icelandic_share_apportionment(
     v_desired_col_sums,
     m_prior_allocations,
     divisor_gen,
+    sum_divisor_gen,
     threshold=None,
     orig_votes=None,
     **kwargs
@@ -28,7 +29,7 @@ def icelandic_share_apportionment(
     seats_info = []
     while num_allocated < total_seats:
         alloc, d = apportion1d(v_votes, num_allocated+1, v_last_alloc,
-                                divisor_gen, invalid=invalid)
+                                sum_divisor_gen, invalid=invalid)
 
         diff = [alloc[j]-v_last_alloc[j] for j in range(len(alloc))]
         idx = diff.index(1)

--- a/backend/methods/icelandic_law_based_on_shares.py
+++ b/backend/methods/icelandic_law_based_on_shares.py
@@ -11,6 +11,8 @@ def icelandic_share_apportionment(
     m_prior_allocations,
     divisor_gen,
     sum_divisor_gen,
+    DIVIDER_RULES,
+    QUOTA_RULES,
     threshold=None,
     orig_votes=None,
     **kwargs
@@ -28,8 +30,26 @@ def icelandic_share_apportionment(
     v_last_alloc = deepcopy(v_seats)
     seats_info = []
     while num_allocated < total_seats:
-        alloc, d = apportion1d(v_votes, num_allocated+1, v_last_alloc,
-                                sum_divisor_gen, invalid=invalid)
+        if sum_divisor_gen in DIVIDER_RULES.values():
+            alloc, d = apportion1d(
+                v_votes=v_votes,
+                num_total_seats=num_allocated+1,
+                prior_allocations=v_last_alloc,
+                divisor_gen=sum_divisor_gen,
+                invalid=invalid
+            )
+            country_num = d[2]
+        else:
+            quota_rule = sum_divisor_gen
+            assert quota_rule in QUOTA_RULES.values()
+            alloc, sequence, next_in = apportion1d_by_quota(
+                v_votes=v_votes,
+                num_total_seats=num_allocated+1,
+                prior_allocations=v_last_alloc,
+                quota_rule=quota_rule,
+                invalid=invalid
+            )
+            country_num = sequence[-1]["active_votes"]
 
         diff = [alloc[j]-v_last_alloc[j] for j in range(len(alloc))]
         idx = diff.index(1)
@@ -59,7 +79,7 @@ def icelandic_share_apportionment(
             seats_info.append({
                 "constituency": const[0], "party": idx,
                 "reason": "Highest list share",
-                "country_num": d[2],
+                "country_num": country_num,
                 "list_share": v_proportions[const[0]],
             })
         else:

--- a/backend/methods/icelandic_law_based_on_shares.py
+++ b/backend/methods/icelandic_law_based_on_shares.py
@@ -2,17 +2,13 @@
 from copy import deepcopy
 import random
 
-from apportion import apportion1d, apportion1d_by_quota
-
 def icelandic_share_apportionment(
     m_votes,
     v_desired_row_sums,
     v_desired_col_sums,
     m_prior_allocations,
     divisor_gen,
-    sum_divisor_gen,
-    DIVIDER_RULES,
-    QUOTA_RULES,
+    adj_seat_gen,
     threshold=None,
     orig_votes=None,
     **kwargs
@@ -27,32 +23,18 @@ def icelandic_share_apportionment(
     total_seats = sum(v_desired_row_sums)
 
     invalid = []
-    v_last_alloc = deepcopy(v_seats)
     seats_info = []
     while num_allocated < total_seats:
-        if sum_divisor_gen in DIVIDER_RULES.values():
-            alloc, d = apportion1d(
-                v_votes=v_votes,
-                num_total_seats=num_allocated+1,
-                prior_allocations=v_last_alloc,
-                divisor_gen=sum_divisor_gen,
-                invalid=invalid
-            )
-            country_num = d[2]
-        else:
-            quota_rule = sum_divisor_gen
-            assert quota_rule in QUOTA_RULES.values()
-            alloc, sequence, next_in = apportion1d_by_quota(
-                v_votes=v_votes,
-                num_total_seats=num_allocated+1,
-                prior_allocations=v_last_alloc,
-                quota_rule=quota_rule,
-                invalid=invalid
-            )
-            country_num = sequence[-1]["active_votes"]
+        #if all parties are either invalid or below threshold,
+        #then no more seats can be allocated
+        if all(p in invalid or v_votes[p] == 0 for p in range(len(v_votes))):
+            raise ValueError(f"No valid recipient of seat nr. {num_allocated+1}")
 
-        diff = [alloc[j]-v_last_alloc[j] for j in range(len(alloc))]
-        idx = diff.index(1)
+        seat = next(adj_seat)
+        while seat["idx"] in invalid:
+            seat = next(adj_seat)
+        country_num = seat["active_votes"]
+        idx = seat["idx"]
 
         v_proportions = []
         for const in range(len(m_votes)):
@@ -75,7 +57,6 @@ def icelandic_share_apportionment(
 
             m_allocations[const[0]][idx] += 1
             num_allocated += 1
-            v_last_alloc = alloc
             seats_info.append({
                 "constituency": const[0], "party": idx,
                 "reason": "Highest list share",

--- a/backend/methods/icelandic_law_based_on_shares.py
+++ b/backend/methods/icelandic_law_based_on_shares.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 import random
 
-from apportion import apportion1d
+from apportion import apportion1d, apportion1d_by_quota
 
 def icelandic_share_apportionment(
     m_votes,

--- a/backend/solution_util.py
+++ b/backend/solution_util.py
@@ -18,13 +18,16 @@ def solution_exists(votes, row_constraints, col_constraints, prior_allocations):
 
     epsilon = 0.0000001
     adjusted_votes = [[v if v>0 else epsilon for v in row] for row in votes]
-    result, _ = alternating_scaling(
-        m_votes=adjusted_votes,
-        v_desired_row_sums=row_constraints,
-        v_desired_col_sums=col_constraints,
-        m_prior_allocations=prior_allocations,
-        divisor_gen=division_rules.dhondt_gen,
-        threshold=0)
+    try:
+        result, _ = alternating_scaling(
+            m_votes=adjusted_votes,
+            v_desired_row_sums=row_constraints,
+            v_desired_col_sums=col_constraints,
+            m_prior_allocations=prior_allocations,
+            divisor_gen=division_rules.dhondt_gen,
+            threshold=0)
+    except RuntimeError:
+        return False
     for c in range(num_constituencies):
         for p in range(num_parties):
             if result[c][p]>prior_allocations[c][p] and votes[c][p]==0:

--- a/backend/tests/apportion1d.py
+++ b/backend/tests/apportion1d.py
@@ -55,3 +55,62 @@ class TestElection(unittest.TestCase):
         #Assert
         self.assertEqual(expected3, results3)
         self.assertEqual(expected4, results4)
+
+    def test_seat_generator_quota(self):
+        #Arrange
+        votes = [135,129,36]
+        repetitions = 2 # Make sure the process is repeatable
+
+        #Act
+        seats, seat_gen = apportion.apportion1d_general(
+            v_votes=votes,
+            num_total_seats=3,
+            prior_allocations=[],
+            rule=division_rules.hare,
+            type_of_rule="Quota"
+        )
+        seat = [[],[]]
+        for i in range(repetitions):
+            gen = seat_gen()
+            for j in range(3):
+                seat[i].append(next(gen))
+
+        #Assert
+        self.assertEqual(seats, [1,1,1])
+        for i in range(repetitions):
+            self.assertEqual(seat[i][0], {'idx': 0, 'active_votes': 135})
+            self.assertEqual(seat[i][1], {'idx': 1, 'active_votes': 129})
+            self.assertEqual(seat[i][2], {'idx': 2, 'active_votes':  36})
+
+    def test_seat_generator_div(self):
+        #Arrange
+        votes = [135,129,36]
+        repetitions = 2 # Make sure the process is repeatable
+
+        #Act
+        seats, seat_gen = apportion.apportion1d_general(
+            v_votes=votes,
+            num_total_seats=3,
+            prior_allocations=[],
+            rule=division_rules.dhondt_gen,
+            type_of_rule="Division"
+        )
+        seat = [[],[]]
+        for i in range(repetitions):
+            gen = seat_gen()
+            for j in range(10):
+                seat[i].append(next(gen))
+
+        #Assert
+        self.assertEqual(seats, [2,1,0])
+        for i in range(repetitions):
+            self.assertEqual(seat[i][0], {'idx': 0, 'active_votes': 135})
+            self.assertEqual(seat[i][1], {'idx': 1, 'active_votes': 129})
+            self.assertEqual(seat[i][2], {'idx': 0, 'active_votes':  67.5})
+            self.assertEqual(seat[i][3], {'idx': 1, 'active_votes':  64.5})
+            self.assertEqual(seat[i][4], {'idx': 0, 'active_votes':  45})
+            self.assertEqual(seat[i][5], {'idx': 1, 'active_votes':  43})
+            self.assertEqual(seat[i][6], {'idx': 2, 'active_votes':  36})
+            self.assertEqual(seat[i][7], {'idx': 0, 'active_votes':  33.75})
+            self.assertEqual(seat[i][8], {'idx': 1, 'active_votes':  32.25})
+            self.assertEqual(seat[i][9], {'idx': 0, 'active_votes':  27})

--- a/backend/tests/apportion1d.py
+++ b/backend/tests/apportion1d.py
@@ -62,7 +62,7 @@ class TestElection(unittest.TestCase):
         repetitions = 2 # Make sure the process is repeatable
 
         #Act
-        seats, seat_gen = apportion.apportion1d_general(
+        seats, seat_gen, _, _ = apportion.apportion1d_general(
             v_votes=votes,
             num_total_seats=3,
             prior_allocations=[],
@@ -88,7 +88,7 @@ class TestElection(unittest.TestCase):
         repetitions = 2 # Make sure the process is repeatable
 
         #Act
-        seats, seat_gen = apportion.apportion1d_general(
+        seats, seat_gen, _, _ = apportion.apportion1d_general(
             v_votes=votes,
             num_total_seats=3,
             prior_allocations=[],

--- a/backend/tests/apportion1d.py
+++ b/backend/tests/apportion1d.py
@@ -62,7 +62,7 @@ class TestElection(unittest.TestCase):
         repetitions = 2 # Make sure the process is repeatable
 
         #Act
-        seats, seat_gen, _, _ = apportion.apportion1d_general(
+        seats, seat_gen, last_in, next_in = apportion.apportion1d_general(
             v_votes=votes,
             num_total_seats=3,
             prior_allocations=[],
@@ -72,15 +72,21 @@ class TestElection(unittest.TestCase):
         seat = [[],[]]
         for i in range(repetitions):
             gen = seat_gen()
-            for j in range(3):
+            for j in range(5):
                 seat[i].append(next(gen))
 
         #Assert
         self.assertEqual(seats, [1,1,1])
+        self.assertEqual(last_in, {'idx': 2, 'active_votes': 36})
+        self.assertEqual(next_in, {'idx': 0, 'active_votes': 35})
         for i in range(repetitions):
             self.assertEqual(seat[i][0], {'idx': 0, 'active_votes': 135})
             self.assertEqual(seat[i][1], {'idx': 1, 'active_votes': 129})
             self.assertEqual(seat[i][2], {'idx': 2, 'active_votes':  36})
+            #note that the quota is based on there being only 3 seats,
+            #but if we were to continue, the sequence would go on as follows:
+            self.assertEqual(seat[i][3], {'idx': 0, 'active_votes':  35})
+            self.assertEqual(seat[i][4], {'idx': 1, 'active_votes':  29})
 
     def test_seat_generator_div(self):
         #Arrange
@@ -88,7 +94,7 @@ class TestElection(unittest.TestCase):
         repetitions = 2 # Make sure the process is repeatable
 
         #Act
-        seats, seat_gen, _, _ = apportion.apportion1d_general(
+        seats, seat_gen, last_in, next_in = apportion.apportion1d_general(
             v_votes=votes,
             num_total_seats=3,
             prior_allocations=[],
@@ -103,10 +109,13 @@ class TestElection(unittest.TestCase):
 
         #Assert
         self.assertEqual(seats, [2,1,0])
+        self.assertEqual(last_in, {'idx': 0, 'active_votes': 67.5})
+        self.assertEqual(next_in, {'idx': 1, 'active_votes': 64.5})
         for i in range(repetitions):
             self.assertEqual(seat[i][0], {'idx': 0, 'active_votes': 135})
             self.assertEqual(seat[i][1], {'idx': 1, 'active_votes': 129})
             self.assertEqual(seat[i][2], {'idx': 0, 'active_votes':  67.5})
+            #the sequence continues beyond the specified 3 seats as follows:
             self.assertEqual(seat[i][3], {'idx': 1, 'active_votes':  64.5})
             self.assertEqual(seat[i][4], {'idx': 0, 'active_votes':  45})
             self.assertEqual(seat[i][5], {'idx': 1, 'active_votes':  43})

--- a/backend/tests/apportion1d.py
+++ b/backend/tests/apportion1d.py
@@ -123,3 +123,36 @@ class TestElection(unittest.TestCase):
             self.assertEqual(seat[i][7], {'idx': 0, 'active_votes':  33.75})
             self.assertEqual(seat[i][8], {'idx': 1, 'active_votes':  32.25})
             self.assertEqual(seat[i][9], {'idx': 0, 'active_votes':  27})
+
+    def test_seat_generator_div_with_prior(self):
+        #Arrange
+        votes = [135,129,36]
+        repetitions = 2 # Make sure the process is repeatable
+
+        #Act
+        seats, seat_gen, last_in, next_in = apportion.apportion1d_general(
+            v_votes=votes,
+            num_total_seats=6,
+            prior_allocations=[2,1,0],
+            rule=division_rules.dhondt_gen,
+            type_of_rule="Division"
+        )
+        seat = [[],[]]
+        for i in range(repetitions):
+            gen = seat_gen()
+            for j in range(7):
+                seat[i].append(next(gen))
+
+        #Assert
+        self.assertEqual(seats, [3,3,0])
+        self.assertEqual(last_in, {'idx': 1, 'active_votes': 43})
+        self.assertEqual(next_in, {'idx': 2, 'active_votes': 36})
+        for i in range(repetitions):
+            self.assertEqual(seat[i][0], {'idx': 1, 'active_votes': 64.5})
+            self.assertEqual(seat[i][1], {'idx': 0, 'active_votes': 45})
+            self.assertEqual(seat[i][2], {'idx': 1, 'active_votes': 43})
+            #the sequence continues beyond the specified 3 seats as follows:
+            self.assertEqual(seat[i][3], {'idx': 2, 'active_votes': 36})
+            self.assertEqual(seat[i][4], {'idx': 0, 'active_votes': 33.75})
+            self.assertEqual(seat[i][5], {'idx': 1, 'active_votes': 32.25})
+            self.assertEqual(seat[i][6], {'idx': 0, 'active_votes': 27})

--- a/backend/tests/apportion1d.py
+++ b/backend/tests/apportion1d.py
@@ -5,16 +5,6 @@ import apportion
 
 class TestElection(unittest.TestCase):
 
-    def test_invalid(self):
-        with self.assertRaises(ValueError):
-            apportion.apportion1d(
-                v_votes=[0,10],
-                num_total_seats=1,
-                prior_allocations=[0,0],
-                divisor_gen=division_rules.dhondt_gen,
-                invalid=[1]
-            )
-
     def test_valid(self):
         #Arrange
         votes    = [1852,2196,7800,1812,1756,1508,4662,1552]
@@ -39,16 +29,18 @@ class TestElection(unittest.TestCase):
         expected4 = [  2,  2,  0]
 
         #Act
-        results3, _, _ = apportion.apportion1d_by_quota(
+        results3, _, _, _ = apportion.apportion1d_general(
             num_total_seats=3,
             v_votes=votes,
-            quota_rule=division_rules.hare,
+            rule=division_rules.hare,
+            type_of_rule="Quota",
             prior_allocations=[],
         )
-        results4, _, _ = apportion.apportion1d_by_quota(
+        results4, _, _, _ = apportion.apportion1d_general(
             num_total_seats=4,
             v_votes=votes,
-            quota_rule=division_rules.hare,
+            rule=division_rules.hare,
+            type_of_rule="Quota",
             prior_allocations=[],
         )
 

--- a/backend/tests/methods.py
+++ b/backend/tests/methods.py
@@ -1,11 +1,10 @@
 from unittest import TestCase
-
 import logging
+
 import util
 import division_rules
 from electionRules import ElectionRules
 from voting import Election
-
 from methods.alternating_scaling import *
 from methods.norwegian_law import norwegian_apportionment
 from methods.norwegian_icelandic import norw_ice_apportionment
@@ -182,6 +181,75 @@ class TestAdjustmentMethods(TestCase):
                                    [1,3,5,0,0,0,0,0,0,0,0,2,0,1,1],
                                    [2,2,3,0,0,0,0,0,0,0,0,2,0,1,1],
                                    [2,1,3,0,0,0,0,0,0,0,0,2,0,2,1]])
+    def test_icelandic_law_lague(self):
+        #Arrange
+        self.rules["parties"] = ["A", "B", "C", "D", "E", "F", "G"]
+        votes = [
+            [ 4882,  2958, 4183, 2814, 1033,  729,  648],
+            [ 5577,  4016, 6132, 4776, 1266, 1011,  830],
+            [ 8383,  5327, 6424, 2785, 2039, 1407, 1687],
+            [18627, 11377, 6477, 6182, 4748, 5795, 2531],
+            [10206,  7457, 3429, 5431, 3631, 3474, 2089],
+            [ 9544,  7644, 3213, 6257, 4126, 3299, 1792],
+        ]
+        #self.rules["seat_spec_option"] = "all_adj"
+        self.rules["constituencies"] = [
+            {"name": "NV", "num_const_seats": 0, "num_adj_seats":  8},
+            {"name": "NA", "num_const_seats": 0, "num_adj_seats": 10},
+            {"name": "S",  "num_const_seats": 0, "num_adj_seats": 10},
+            {"name": "SV", "num_const_seats": 0, "num_adj_seats": 13},
+            {"name": "RS", "num_const_seats": 0, "num_adj_seats": 11},
+            {"name": "RN", "num_const_seats": 0, "num_adj_seats": 11},
+        ]
+        self.rules["adjustment_method"] = "icelandic-law"
+        self.rules["primary_divider"] = "dhondt" #Irrelevant, b/c 0 const seats
+        dd_rules = self.rules
+        dd_rules["adj_determine_divider"] = "dhondt"
+        dd_rules["adj_alloc_divider"]     = "dhondt"
+        sd_rules = ElectionRules()
+        sd_rules.update(dd_rules)
+        sd_rules["adj_determine_divider"] = "sainte-lague"
+        sd_rules["adj_alloc_divider"]     = "dhondt"
+        ss_rules = ElectionRules()
+        ss_rules.update(sd_rules)
+        ss_rules["adj_determine_divider"] = "sainte-lague"
+        ss_rules["adj_alloc_divider"]     = "sainte-lague"
+        dd_election = Election(dd_rules, votes)
+        sd_election = Election(sd_rules, votes)
+        ss_election = Election(ss_rules, votes)
+
+        #Act
+        dd_results = dd_election.run()
+        sd_results = sd_election.run()
+        ss_results = ss_election.run()
+
+        #Assert
+        self.assertEqual(dd_election.v_desired_col_sums,
+            [20, 13, 10, 10, 5, 5, 0] #based on dHondt
+        )
+        v_dd_results = [sum(x) for x in zip(*dd_results)]
+        self.assertEqual(v_dd_results,
+            [20, 13, 10, 10, 5, 5, 0] #based on dHondt
+        )
+
+        self.assertEqual(sd_election.v_desired_col_sums,
+            [19, 13, 10, 10, 6, 5, 0] #based on Sainte-Lague
+        )
+        v_sd_results = [sum(x) for x in zip(*sd_results)]
+        self.assertNotEqual(v_sd_results,
+            [20, 13, 10, 10, 5, 5, 0] #based on dHondt
+        )
+        self.assertEqual(v_sd_results,
+            [19, 13, 10, 10, 6, 5, 0] #based on Sainte-Lague
+        )
+
+        self.assertEqual(ss_election.v_desired_col_sums,
+            [19, 13, 10, 10, 6, 5, 0] #based on Sainte-Lague
+        )
+        v_ss_results = [sum(x) for x in zip(*ss_results)]
+        self.assertEqual(v_ss_results,
+            [19, 13, 10, 10, 6, 5, 0] #based on Sainte-Lague
+        )
     def test_switching(self):
         self.rules["adjustment_method"] = "switching"
         election = Election(self.rules, self.votes)

--- a/backend/tests/methods.py
+++ b/backend/tests/methods.py
@@ -250,6 +250,17 @@ class TestAdjustmentMethods(TestCase):
         self.assertEqual(v_ss_results,
             [19, 13, 10, 10, 6, 5, 0] #based on Sainte-Lague
         )
+    def test_icelandic_law_hare(self):
+        self.rules["adjustment_method"] = "icelandic-law"
+        self.rules["adj_determine_divider"] = "hare"
+        election = Election(self.rules, self.votes)
+        results = election.run()
+        self.assertEqual(results, [[0,4,2,0,0,0,0,0,0,0,0,1,0,1,0],
+                                   [1,4,2,0,0,0,0,0,0,0,0,1,0,2,0],
+                                   [1,4,4,0,0,0,0,0,0,0,0,1,0,0,0],
+                                   [1,3,5,0,0,0,0,0,0,0,0,2,0,1,1],
+                                   [2,2,3,0,0,0,0,0,0,0,0,2,0,1,1],
+                                   [1,2,3,0,0,0,0,0,0,0,0,2,0,2,1]])
     def test_switching(self):
         self.rules["adjustment_method"] = "switching"
         election = Election(self.rules, self.votes)

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -157,6 +157,8 @@ class Election:
                 m_prior_allocations=self.m_const_seats_alloc,
                 divisor_gen=self.gen,
                 sum_divisor_gen=self.rules.get_generator("adj_determine_divider"),
+                DIVIDER_RULES=DIVIDER_RULES,
+                QUOTA_RULES=QUOTA_RULES,
                 threshold=self.rules["adjustment_threshold"],
                 orig_votes=self.m_votes,
                 v_const_seats=[con["num_const_seats"] for con in consts],

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -162,7 +162,8 @@ class Election:
                 threshold=self.rules["adjustment_threshold"],
                 orig_votes=self.m_votes,
                 v_const_seats=[con["num_const_seats"] for con in consts],
-                last=self.last)
+                last=self.last #for nearest_neighbor and relative_inferiority
+            )
         except (ZeroDivisionError, RuntimeError):
             self.results = self.m_const_seats_alloc
             self.adj_seats_info = None

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -69,25 +69,22 @@ class Election:
         for i in range(self.num_constituencies):
             num_seats = constituencies[i]["num_const_seats"]
             if num_seats != 0:
+                rule_type = ""
                 if self.rules["primary_divider"] in DIVIDER_RULES.keys():
-                    alloc, seat_gen, last_in, next_in = apportion1d_general(
-                        v_votes=self.m_votes[i],
-                        num_total_seats=num_seats,
-                        prior_allocations=[],
-                        rule=self.rules.get_generator("primary_divider"),
-                        type_of_rule="Division",
-                        threshold=self.rules["constituency_threshold"])
-                    self.last.append(last_in["active_votes"])
+                    rule_type = "Division"
                 else:
                     assert self.rules["primary_divider"] in QUOTA_RULES.keys()
-                    alloc, seat_gen, last_in, next_in = apportion1d_general(
-                        v_votes=self.m_votes[i],
-                        num_total_seats=num_seats,
-                        prior_allocations=[],
-                        rule=self.rules.get_generator("primary_divider"),
-                        type_of_rule="Quota",
-                        threshold=self.rules["constituency_threshold"])
-                    self.last.append(last_in["active_votes"])
+                    rule_type = "Quota"
+                alloc, seat_gen, last_in, next_in = apportion1d_general(
+                    v_votes=self.m_votes[i],
+                    num_total_seats=num_seats,
+                    prior_allocations=[],
+                    rule=self.rules.get_generator("primary_divider"),
+                    type_of_rule=rule_type,
+                    threshold=self.rules["constituency_threshold"]
+                )
+                assert last_in #last_in is not None because num_seats > 0
+                self.last.append(last_in["active_votes"])
             else:
                 alloc = [0]*self.num_parties
                 self.last.append(0)

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -6,7 +6,7 @@ from tabulate import tabulate
 
 from table_util import entropy, add_totals
 from solution_util import solution_exists
-from apportion import apportion1d, apportion1d_by_quota, \
+from apportion import apportion1d, apportion1d_by_quota, apportion1d_general, \
     threshold_elimination_totals, threshold_elimination_constituencies
 from electionRules import ElectionRules
 from dictionaries import ADJUSTMENT_METHODS, DIVIDER_RULES, QUOTA_RULES
@@ -70,22 +70,24 @@ class Election:
             num_seats = constituencies[i]["num_const_seats"]
             if num_seats != 0:
                 if self.rules["primary_divider"] in DIVIDER_RULES.keys():
-                    alloc, div = apportion1d(
-                        v_votes=self.m_votes[i],
-                        num_total_seats=num_seats,
-                        prior_allocations=[0]*self.num_parties,
-                        divisor_gen=self.rules.get_generator("primary_divider"),
-                        threshold=self.rules["constituency_threshold"])
-                    self.last.append(div[2])
-                else:
-                    assert self.rules["primary_divider"] in QUOTA_RULES.keys()
-                    alloc, sequence, next_in = apportion1d_by_quota(
+                    alloc, seat_gen, last_in, next_in = apportion1d_general(
                         v_votes=self.m_votes[i],
                         num_total_seats=num_seats,
                         prior_allocations=[],
-                        quota_rule=self.rules.get_generator("primary_divider"),
+                        rule=self.rules.get_generator("primary_divider"),
+                        type_of_rule="Division",
                         threshold=self.rules["constituency_threshold"])
-                    self.last.append(sequence[-1]["active_votes"])
+                    self.last.append(last_in["active_votes"])
+                else:
+                    assert self.rules["primary_divider"] in QUOTA_RULES.keys()
+                    alloc, seat_gen, last_in, next_in = apportion1d_general(
+                        v_votes=self.m_votes[i],
+                        num_total_seats=num_seats,
+                        prior_allocations=[],
+                        rule=self.rules.get_generator("primary_divider"),
+                        type_of_rule="Quota",
+                        threshold=self.rules["constituency_threshold"])
+                    self.last.append(last_in["active_votes"])
             else:
                 alloc = [0]*self.num_parties
                 self.last.append(0)

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -69,13 +69,12 @@ class Election:
         for i in range(self.num_constituencies):
             num_seats = constituencies[i]["num_const_seats"]
             if num_seats != 0:
-                rule_type = ""
                 if self.rules["primary_divider"] in DIVIDER_RULES.keys():
                     rule_type = "Division"
                 else:
                     assert self.rules["primary_divider"] in QUOTA_RULES.keys()
                     rule_type = "Quota"
-                alloc, seat_gen, last_in, next_in = apportion1d_general(
+                alloc, _, last_in, _ = apportion1d_general(
                     v_votes=self.m_votes[i],
                     num_total_seats=num_seats,
                     prior_allocations=[],
@@ -117,19 +116,21 @@ class Election:
         if self.rules["debug"]:
             print(" + Determine adjustment seats")
         if self.rules["adj_determine_divider"] in DIVIDER_RULES.keys():
-            self.v_desired_col_sums, _ = apportion1d(
+            self.v_desired_col_sums, seat_gen, _, _ = apportion1d_general(
                 v_votes=self.v_votes,
                 num_total_seats=self.total_seats,
                 prior_allocations=self.v_const_seats_alloc,
-                divisor_gen=self.rules.get_generator("adj_determine_divider"),
+                rule=self.rules.get_generator("adj_determine_divider"),
+                type_of_rule="Division",
                 threshold=self.rules["adjustment_threshold"])
         else:
             assert self.rules["adj_determine_divider"] in QUOTA_RULES.keys()
-            self.v_desired_col_sums, _, _ = apportion1d_by_quota(
+            self.v_desired_col_sums, seat_gen, _, _ = apportion1d_general(
                 v_votes=self.v_votes,
                 num_total_seats=self.total_seats,
                 prior_allocations=self.v_const_seats_alloc,
-                quota_rule=self.rules.get_generator("adj_determine_divider"),
+                rule=self.rules.get_generator("adj_determine_divider"),
+                type_of_rule="Quota",
                 threshold=self.rules["adjustment_threshold"])
         return self.v_desired_col_sums
 

--- a/backend/voting.py
+++ b/backend/voting.py
@@ -156,6 +156,7 @@ class Election:
                 v_desired_col_sums=self.v_desired_col_sums,
                 m_prior_allocations=self.m_const_seats_alloc,
                 divisor_gen=self.gen,
+                sum_divisor_gen=self.rules.get_generator("adj_determine_divider"),
                 threshold=self.rules["adjustment_threshold"],
                 orig_votes=self.m_votes,
                 v_const_seats=[con["num_const_seats"] for con in consts],

--- a/vue-frontend/package.json
+++ b/vue-frontend/package.json
@@ -13,14 +13,14 @@
     "style-loader": "^0.21.0",
     "vue-loader": "^15.2.6",
     "vue-style-loader": "^4.1.1",
-    "vue-template-compiler": "^2.5.16",
+    "vue-template-compiler": "^2.6.10",
     "webpack": "^4.16.2",
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
-    "bootstrap-vue": "^2.0.0-rc.11",
+    "bootstrap-vue": "^2.0.3",
     "chart.js": "^2.7.2",
-    "vue": "^2.5.16",
+    "vue": "^2.6.10",
     "vue-chartjs": "^3.3.2",
     "vue-resource": "^1.5.1",
     "vue-router": "^3.0.1"

--- a/vue-frontend/src/Main.vue
+++ b/vue-frontend/src/Main.vue
@@ -82,7 +82,7 @@
             @update-rules="updateElectionRulesAndActivate">
           </ElectionSettings>
         </b-tab>
-        <template slot="tabs">
+        <template v-slot:tabs-end>
           <b-button size="sm" @click="addElectionRules"><b>+</b></b-button>
         </template>
         <div slot="empty">

--- a/vue-frontend/src/components/VoteMatrix.vue
+++ b/vue-frontend/src/components/VoteMatrix.vue
@@ -82,7 +82,7 @@
       cancel-only
     >
       <b-table hover :items="presets" :fields="presetfields">
-        <template slot="actions" slot-scope="row">
+        <template v-slot:cell(actions)="row">
           <b-button size="sm"
             @click.stop="loadPreset(row.item.id); $refs.modalpresetref.hide()"
             class="mr-1 mt-0 mb-0"


### PR DESCRIPTION
- Make sure Icelandic law refers to rule for dividing adjustment seats nationally when deciding which party should get next adjustment seat (until now Icelandic law method has actually been ignoring the desired national division and just using the rule that is specified for allocation of adjustment seats instead)
- This introduced a problem with mixing quota methods into Icelandic law two-dimensional apportionment method.
- Fix this by introducing seat generators, and have the two-dimensional apportionment methods use those instead.

- Update vue dependency, changing the code where necessary.